### PR TITLE
Support external loading of selector options

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,6 +34,7 @@ dependencies {
         exclude group: 'com.nineoldandroids', module: 'library'
         exclude group: 'com.android.support', module: 'appcompat-v7'
     }
+    compile 'com.jayway.jsonpath:json-path:2.3.0'
 }
 sonarqube {
     properties {

--- a/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
+++ b/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
@@ -12,6 +12,7 @@ import android.view.WindowManager;
 
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.fragments.JsonFormFragment;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.JsonApi;
@@ -31,6 +32,7 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
     private JSONObject mJSONObject;
     private int mVisualizationMode;
     private JsonFormBundle mJsonBundle;
+    private JsonExpressionResolver mResolver;
 
     public void init(String json, Integer visualizationMode) {
         try {
@@ -170,6 +172,18 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
             }
         }
         return mJsonBundle;
+    }
+
+    @Override
+    public JsonExpressionResolver getExpressionResolver() {
+        if (mResolver==null) {
+            try {
+                mResolver = new JsonExpressionResolver(mJSONObject);
+            } catch (JSONException e) {
+                Log.e(TAG, e.getMessage(), e);
+            }
+        }
+        return mResolver;
     }
 
     private void configureInputMethod() {

--- a/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
@@ -56,7 +56,11 @@ public class JsonExpressionResolver {
         if (array.length() == 0) {
             return null;
         }
-        return array.getJSONArray(0);
+        Object item = array.get(0);
+        if (item instanceof JSONArray) {
+            return (JSONArray) item;
+        }
+        return array;
     }
 
     static {

--- a/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
@@ -1,0 +1,86 @@
+package com.vijay.jsonwizard.expressions;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import java.util.EnumSet;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class JsonExpressionResolver {
+
+    private JSONObject dataObject;
+    private DocumentContext dataDocumentContext;
+
+    public JsonExpressionResolver(JSONObject form) throws JSONException {
+        if (form.has("data")) {
+            dataObject = form.getJSONObject("data");
+            dataDocumentContext = JsonPath.parse(dataObject);
+        }
+    }
+
+    public boolean isValidExpression(String expression) {
+        if (expression == null) {
+            return false;
+        }
+        return expression.startsWith("$.");
+    }
+
+    public String resolveAsString(String expression) throws JSONException {
+        JSONArray array = dataDocumentContext.read(expression);
+        if (array.length() == 0) {
+            return null;
+        }
+        return array.getString(0);
+    }
+
+
+    public JSONObject resolveAsObject(String expression) throws JSONException {
+        JSONArray array = dataDocumentContext.read(expression);
+        if (array.length() == 0) {
+            return null;
+        }
+        return array.getJSONObject(0);
+    }
+
+    public JSONArray resolveAsArray(String expression) throws JSONException {
+        JSONArray array = dataDocumentContext.read(expression);
+        if (array.length() == 0) {
+            return null;
+        }
+        return array.getJSONArray(0);
+    }
+
+    static {
+        Configuration.setDefaults(new Configuration.Defaults() {
+
+            private final JsonProvider jsonProvider = new JsonOrgJsonProvider();
+            private final MappingProvider mappingProvider = new JsonOrgMappingProvider();
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return jsonProvider;
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return mappingProvider;
+            }
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.of(Option.DEFAULT_PATH_LEAF_TO_NULL,
+                        Option.ALWAYS_RETURN_LIST);
+            }
+        });
+    }
+
+}

--- a/library/src/main/java/com/vijay/jsonwizard/fragments/JsonFormFragment.java
+++ b/library/src/main/java/com/vijay/jsonwizard/fragments/JsonFormFragment.java
@@ -28,6 +28,7 @@ import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.activities.JsonFormActivity;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.customviews.RadioButton;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.JsonApi;
@@ -339,5 +340,10 @@ public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, Jso
     @Override
     public JsonFormBundle getBundle(Locale locale) {
         return mJsonApi.getBundle(locale);
+    }
+
+    @Override
+    public JsonExpressionResolver getExpressionResolver() {
+        return mJsonApi.getExpressionResolver();
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/interactors/JsonFormInteractor.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interactors/JsonFormInteractor.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import android.view.View;
 
 import com.vijay.jsonwizard.constants.JsonFormConstants;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
@@ -39,7 +40,7 @@ public class JsonFormInteractor {
     private JsonFormInteractor() {
     }
 
-    public List<View> fetchFormElements(String stepName, Context context, JSONObject parentJson, CommonListener listener, JsonFormBundle bundle, int visualizationMode) {
+    public List<View> fetchFormElements(String stepName, Context context, JSONObject parentJson, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) {
         Log.d(TAG, "fetchFormElements called");
         List<View> viewsFromJson = new ArrayList<>(5);
         try {
@@ -48,7 +49,7 @@ public class JsonFormInteractor {
                 JSONObject childJson = fields.getJSONObject(i);
                 try {
                     List<View> views = WidgetFactoryRegistry.getWidgetFactory(childJson.getString("type")).
-                            getViewsFromJson(stepName, context, childJson, listener, bundle, visualizationMode);
+                            getViewsFromJson(stepName, context, childJson, listener, bundle, resolver, visualizationMode);
                     if (views.size() > 0) {
                         viewsFromJson.addAll(views);
                     }

--- a/library/src/main/java/com/vijay/jsonwizard/interfaces/FormWidgetFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interfaces/FormWidgetFactory.java
@@ -3,6 +3,7 @@ package com.vijay.jsonwizard.interfaces;
 import android.content.Context;
 import android.view.View;
 
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 
 import org.json.JSONObject;
@@ -15,6 +16,8 @@ import java.util.Map;
  */
 public interface FormWidgetFactory {
 
-    List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws Exception;
+    List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject,
+            CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
+            int visualizationMode) throws Exception;
 
 }

--- a/library/src/main/java/com/vijay/jsonwizard/interfaces/JsonApi.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interfaces/JsonApi.java
@@ -1,5 +1,6 @@
 package com.vijay.jsonwizard.interfaces;
 
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 
 import org.json.JSONException;
@@ -25,4 +26,6 @@ public interface JsonApi {
     int getVisualizationMode();
 
     JsonFormBundle getBundle(Locale locale);
+
+    JsonExpressionResolver getExpressionResolver();
 }

--- a/library/src/main/java/com/vijay/jsonwizard/presenters/JsonFormFragmentPresenter.java
+++ b/library/src/main/java/com/vijay/jsonwizard/presenters/JsonFormFragmentPresenter.java
@@ -20,6 +20,7 @@ import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.customviews.CheckBox;
 import com.vijay.jsonwizard.customviews.RadioButton;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.fragments.JsonFormFragment;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interactors.JsonFormInteractor;
@@ -71,13 +72,14 @@ public class JsonFormFragmentPresenter extends MvpBasePresenter<JsonFormFragment
         mStepName = getView().getArguments().getString("stepName");
         JSONObject step = getView().getStep(mStepName);
         JsonFormBundle bundle = getView().getBundle(getView().getContext().getResources().getConfiguration().locale);
+        JsonExpressionResolver resolver = getView().getExpressionResolver();
 
         try {
             mStepDetails = new JSONObject(step.toString());
         } catch (JSONException e) {
             Log.e(TAG, e.getMessage(), e);
         }
-        List<View> views = getStepFormElements(mStepName, mStepDetails, bundle);
+        List<View> views = getStepFormElements(mStepName, mStepDetails, bundle, resolver);
         getView().addFormElements(views);
     }
 
@@ -85,13 +87,14 @@ public class JsonFormFragmentPresenter extends MvpBasePresenter<JsonFormFragment
         String stepName = getView().getArguments().getString("stepName");
         JSONObject step = getView().getStep(stepName);
         JsonFormBundle bundle = getView().getBundle(getView().getContext().getResources().getConfiguration().locale);
+        JsonExpressionResolver resolver = getView().getExpressionResolver();
 
-        List<View> views = getStepFormElements(stepName, step, bundle);
+        List<View> views = getStepFormElements(stepName, step, bundle,resolver);
         if(step.has("next")){
             try{
                 stepName = step.getString("next");
                 step = getView().getStep(stepName);
-                views.addAll(getStepFormElements(stepName, step, bundle));
+                views.addAll(getStepFormElements(stepName, step, bundle,resolver));
             } catch (JSONException e) {
                 Log.e(TAG, e.getMessage(), e);
             }
@@ -99,9 +102,9 @@ public class JsonFormFragmentPresenter extends MvpBasePresenter<JsonFormFragment
         getView().addFormElements(views);
     }
 
-    private List<View> getStepFormElements(String stepName, JSONObject stepDetails, JsonFormBundle bundle){
+    private List<View> getStepFormElements(String stepName, JSONObject stepDetails, JsonFormBundle bundle, JsonExpressionResolver resolver){
         List<View> views = mJsonFormInteractor.fetchFormElements(stepName, getView().getContext(), stepDetails,
-                getView().getCommonListener(), bundle, mVisualizationMode);
+                getView().getCommonListener(), bundle, resolver, mVisualizationMode);
         return views;
     }
 

--- a/library/src/main/java/com/vijay/jsonwizard/views/JsonFormFragmentView.java
+++ b/library/src/main/java/com/vijay/jsonwizard/views/JsonFormFragmentView.java
@@ -1,5 +1,6 @@
 package com.vijay.jsonwizard.views;
 
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import java.util.List;
 import java.util.Locale;
 
@@ -70,4 +71,6 @@ public interface JsonFormFragmentView<VS extends ViewState> extends MvpView {
     String getCount();
 
     JsonFormBundle getBundle(Locale locale);
+
+    JsonExpressionResolver getExpressionResolver();
 }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/CheckBoxFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/CheckBoxFactory.java
@@ -11,6 +11,7 @@ import android.widget.LinearLayout;
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.customviews.CheckBox;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
@@ -30,7 +31,7 @@ import static com.vijay.jsonwizard.utils.FormUtils.*;
 public class CheckBoxFactory implements FormWidgetFactory {
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = null;
         switch (visualizationMode){
             case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/DatePickerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/DatePickerFactory.java
@@ -6,27 +6,25 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
-
 import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rey.material.app.DatePickerDialog;
 import com.rey.material.app.Dialog;
 import com.rey.material.util.ViewUtil;
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.utils.DateUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Created by jurkiri on 16/11/17.
@@ -37,7 +35,7 @@ public class DatePickerFactory implements FormWidgetFactory {
     private static final String TAG = "DatePickerFactory";
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = null;
         switch (visualizationMode){
             case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/EditGroupFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/EditGroupFactory.java
@@ -9,6 +9,7 @@ import android.widget.LinearLayout;
 
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
@@ -35,7 +36,7 @@ public class EditGroupFactory implements FormWidgetFactory {
     private static final String TAG = "EditGroupFactory";
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject parentJson, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject parentJson, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> viewsFromJson = new ArrayList<>();
 
         LinearLayout linearLayout = new LinearLayout(context);
@@ -60,7 +61,7 @@ public class EditGroupFactory implements FormWidgetFactory {
             for (int i = 0; i < optNumber; i++) {
                 JSONObject childJson = fields.getJSONObject(i);
                 try {
-                    List<View> views = WidgetFactoryRegistry.getWidgetFactory(childJson.getString("type")).getViewsFromJson(stepName, context, childJson, listener, bundle, visualizationMode);
+                    List<View> views = WidgetFactoryRegistry.getWidgetFactory(childJson.getString("type")).getViewsFromJson(stepName, context, childJson, listener, bundle,resolver, visualizationMode);
                     for (View v : views) {
                         LinearLayout.LayoutParams layoutParams=new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
                         layoutParams.setMargins(0,0,10,0);

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/EditTextFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/EditTextFactory.java
@@ -13,6 +13,7 @@ import com.rey.material.util.ViewUtil;
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.customviews.GenericTextWatcher;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
@@ -36,7 +37,7 @@ public class EditTextFactory implements FormWidgetFactory {
     public static final int MAX_LENGTH = 100;
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = null;
         switch (visualizationMode){
             case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/ImagePickerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/ImagePickerFactory.java
@@ -7,6 +7,7 @@ import android.widget.Button;
 import android.widget.ImageView;
 
 import com.vijay.jsonwizard.R;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
@@ -30,7 +31,7 @@ import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
 public class ImagePickerFactory implements FormWidgetFactory {
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = new ArrayList<>(1);
         ImageView imageView = new ImageView(context);
         imageView.setImageDrawable(context.getResources().getDrawable(R.mipmap.grey_bg));

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/LabelFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/LabelFactory.java
@@ -5,6 +5,7 @@ import android.view.View;
 import android.widget.LinearLayout;
 
 import com.vijay.jsonwizard.R;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
@@ -26,7 +27,7 @@ import static com.vijay.jsonwizard.utils.FormUtils.getTextViewWith;
 public class LabelFactory implements FormWidgetFactory {
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = new ArrayList<>(1);
         LinearLayout.LayoutParams layoutParams = getLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 0, 0, 0, (int) context
                 .getResources().getDimension(R.dimen.default_bottom_margin));

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/SeparatorFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/SeparatorFactory.java
@@ -7,6 +7,7 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
 import com.vijay.jsonwizard.R;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
@@ -24,7 +25,7 @@ import java.util.List;
 public class SeparatorFactory implements FormWidgetFactory {
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = new ArrayList<>(1);
         View v = new View(context);
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);


### PR DESCRIPTION
This PR allows to include a "data" member in the json form deffinition document with data that can be referenced from the Spinner and Radiobutton widgets.

These widgets can now use a JSONPath expression over the JSON object included into the "data" member as a mechanism for calculating the options of the Radiobutton widget and the values of the Spinner widget.

Fix #6 