### PR TITLE
Support for cascading spinners and radio button selectors

### DIFF
--- a/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
@@ -51,8 +51,14 @@ public class JsonExpressionResolver {
         return array.getJSONObject(0);
     }
 
-    public JSONArray resolveAsArray(String expression) throws JSONException {
+    public JSONArray resolveAsArray(String expression, JSONObject instance) throws JSONException {
+        if (instance != null) {
+            dataDocumentContext.put("$", "current-values", instance);
+        }
         JSONArray array = dataDocumentContext.read(expression);
+
+        dataDocumentContext.delete("current-values");
+
         if (array.length() == 0) {
             return null;
         }

--- a/library/src/main/java/com/vijay/jsonwizard/utils/JsonFormUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/JsonFormUtils.java
@@ -1,0 +1,64 @@
+package com.vijay.jsonwizard.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class JsonFormUtils {
+
+    public static JSONObject extractDataFromForm(JSONObject form)
+            throws JSONException {
+        Map<String, Object> dataMap = new HashMap<>();
+
+        JSONArray names = form.names();
+        for (int i = 0; i < names.length(); i++) {
+            String nodeName = names.get(i).toString();
+            if (nodeName.contains("step")) {
+                processFieldContainer((JSONObject) form.get(nodeName), dataMap);
+            }
+        }
+        return new JSONObject(dataMap);
+    }
+
+    private static void processFieldContainer(JSONObject container, Map<String, Object> dataMap)
+            throws JSONException {
+        JSONArray fields = container.optJSONArray("fields");
+        if (fields != null) {
+            for (int i = 0; i < fields.length(); i++) {
+                JSONObject field = (JSONObject) fields.get(i);
+                if (isContainer(field)) {
+                    processFieldContainer(field, dataMap);
+                } else {
+                    if (field.has("key") && field.has("value")) {
+                        dataMap.put(field.getString("key"), field.get("value"));
+                    } else if (isCheckbox(field)) {
+                        processCheckbox(field,dataMap);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void processCheckbox(JSONObject field, Map<String, Object> dataMap)
+            throws JSONException {
+        JSONArray options = field.optJSONArray("options");
+        if (options != null) {
+            for (int j = 0; j < options.length(); j++) {
+                JSONObject option = (JSONObject) options.get(j);
+                if (option.has("key") && option.has("value")) {
+                    dataMap.put(option.getString("key"), option.get("value"));
+                }
+            }
+        }
+    }
+
+    private static boolean isContainer(JSONObject field) throws JSONException {
+        return "edit_group".equals(field.getString("type"));
+    }
+
+    private static boolean isCheckbox(JSONObject field) throws JSONException {
+        return "check_box".equals(field.getString("type"));
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/RadioButtonFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/RadioButtonFactory.java
@@ -2,6 +2,7 @@ package com.vijay.jsonwizard.widgets;
 
 import android.content.Context;
 import android.graphics.Typeface;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -18,6 +19,8 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 
+import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.JsonFormUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -61,7 +64,8 @@ public class RadioButtonFactory implements FormWidgetFactory {
         JSONArray options = null;
         String valuesExpression = getValuesAsJsonExpression(jsonObject, resolver);
         if (valuesExpression!=null) {
-            options = resolver.resolveAsArray(valuesExpression);
+            JSONObject currentValues = getCurrentValues(context);
+            options = resolver.resolveAsArray(valuesExpression,currentValues);
         } else {
             options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
         }
@@ -102,6 +106,17 @@ public class RadioButtonFactory implements FormWidgetFactory {
             return valuesExpression;
         }
         return null;
+    }
+
+    @Nullable
+    private JSONObject getCurrentValues(Context context) throws JSONException {
+        JSONObject currentValues = null;
+        if (context instanceof JsonApi) {
+            String currentJsonState = ((JsonApi) context).currentJsonState();
+            JSONObject currentJsonObject = new JSONObject(currentJsonState);
+            currentValues =  JsonFormUtils.extractDataFromForm(currentJsonObject);
+        }
+        return currentValues;
     }
 
 

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/SpinnerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/SpinnerFactory.java
@@ -1,6 +1,7 @@
 package com.vijay.jsonwizard.widgets;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +15,8 @@ import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
+import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.JsonFormUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
 
 import org.json.JSONArray;
@@ -24,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import fr.ganfra.materialspinner.MaterialSpinner;
+import org.json.JSONTokener;
 
 /**
  * Created by nipun on 30/05/15.
@@ -80,7 +84,8 @@ public class SpinnerFactory implements FormWidgetFactory {
         if (valuesExpression == null) {
             valuesJson = jsonObject.optJSONArray("values");
         } else {
-            valuesJson = resolver.resolveAsArray(valuesExpression);
+            JSONObject currentValues = getCurrentValues(context);
+            valuesJson = resolver.resolveAsArray(valuesExpression,currentValues);
         }
 
         String[] values = getValues(valuesJson);
@@ -95,10 +100,21 @@ public class SpinnerFactory implements FormWidgetFactory {
         return views;
     }
 
+    @Nullable
+    private JSONObject getCurrentValues(Context context) throws JSONException {
+        JSONObject currentValues = null;
+        if (context instanceof JsonApi) {
+           String currentJsonState = ((JsonApi) context).currentJsonState();
+           JSONObject currentJsonObject = new JSONObject(currentJsonState);
+           currentValues =  JsonFormUtils.extractDataFromForm(currentJsonObject);
+        }
+        return currentValues;
+    }
+
     private String[] getValues(JSONArray valuesJson) {
         String[] values = null;
-        final int valuesJsonLength = valuesJson.length();
-        if (valuesJson != null && valuesJsonLength > 0) {
+        if (valuesJson != null && valuesJson.length() > 0) {
+            final int valuesJsonLength = valuesJson.length();
             values = new String[valuesJsonLength];
             for (int i = 0; i < valuesJsonLength; i++) {
                 values[i] = valuesJson.optString(i);


### PR DESCRIPTION
JSONPath expression can reference to previous form selections. 

Current form values are added as a "current-values" object in the expression evaluation context.

Fix #7 