### PR TITLE
Support for "show" attribute in any widget

### DIFF
--- a/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
@@ -7,6 +7,7 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
@@ -149,7 +150,13 @@ public class JsonExpressionResolver {
         if (instance != null) {
             localContext.put("$", "current-values", instance);
         }
-        JSONArray array = localContext.read(localExpression);
+        JSONArray array = new JSONArray();
+        try {
+            array = localContext.read(localExpression);
+        } catch (PathNotFoundException e) {
+            Log.d("ExpressionResolver", "existsExpression: checking for missing path "+localExpression);
+        }
+
         localContext.delete("current-values");
 
         return array.length() > 0;

--- a/library/src/main/java/com/vijay/jsonwizard/interactors/JsonFormInteractor.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interactors/JsonFormInteractor.java
@@ -1,6 +1,8 @@
 package com.vijay.jsonwizard.interactors;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 
@@ -9,6 +11,8 @@ import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
+import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.JsonFormUtils;
 import com.vijay.jsonwizard.widgets.CheckBoxFactory;
 import com.vijay.jsonwizard.widgets.DatePickerFactory;
 import com.vijay.jsonwizard.widgets.EditGroupFactory;
@@ -40,29 +44,68 @@ public class JsonFormInteractor {
     private JsonFormInteractor() {
     }
 
-    public List<View> fetchFormElements(String stepName, Context context, JSONObject parentJson, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) {
+    public List<View> fetchFormElements(String stepName, Context context, JSONObject parentJson,
+            CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
+            int visualizationMode) {
         Log.d(TAG, "fetchFormElements called");
         List<View> viewsFromJson = new ArrayList<>(5);
         try {
             JSONArray fields = parentJson.getJSONArray("fields");
             for (int i = 0; i < fields.length(); i++) {
                 JSONObject childJson = fields.getJSONObject(i);
-                try {
-                    List<View> views = WidgetFactoryRegistry.getWidgetFactory(childJson.getString("type")).
-                            getViewsFromJson(stepName, context, childJson, listener, bundle, resolver, visualizationMode);
-                    if (views.size() > 0) {
-                        viewsFromJson.addAll(views);
+                if (isVisible(childJson, context, resolver)) {
+                    try {
+                        List<View> views = WidgetFactoryRegistry
+                                .getWidgetFactory(childJson.getString("type")).
+                                        getViewsFromJson(stepName, context, childJson, listener,
+                                                bundle,
+                                                resolver, visualizationMode);
+                        if (views.size() > 0) {
+                            viewsFromJson.addAll(views);
+                        }
+                    } catch (Exception e) {
+                        Log.e(TAG,
+                                "Exception occurred in making child view at index : " + i
+                                        + " : Exception is : "
+                                        + e.getMessage(), e);
                     }
-                } catch (Exception e) {
-                    Log.e(TAG,
-                            "Exception occurred in making child view at index : " + i + " : Exception is : "
-                                    + e.getMessage(), e);
                 }
             }
         } catch (JSONException e) {
             Log.e(TAG, "Json exception occurred : " + e.getMessage(), e);
         }
         return viewsFromJson;
+    }
+
+    private boolean isVisible(JSONObject jsonObject, Context context,
+            JsonExpressionResolver resolver) {
+
+        final String showExpression = jsonObject.optString("show");
+        if (TextUtils.isEmpty(showExpression)) {
+            return true;
+        }
+        if (resolver.isValidExpression(showExpression)) {
+            try {
+                JSONObject currentValues = getCurrentValues(context);
+                return resolver.existsExpression(showExpression, currentValues);
+            } catch (JSONException e) {
+                Log.e(TAG, "isVisible: Error evaluating expression " + showExpression, e);
+            }
+            return false;
+        }
+
+        return ("true".equalsIgnoreCase(showExpression));
+    }
+
+    @Nullable
+    private JSONObject getCurrentValues(Context context) throws JSONException {
+        JSONObject currentValues = null;
+        if (context instanceof JsonApi) {
+            String currentJsonState = ((JsonApi) context).currentJsonState();
+            JSONObject currentJsonObject = new JSONObject(currentJsonState);
+            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
+        }
+        return currentValues;
     }
 
     public static JsonFormInteractor getInstance() {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/CheckBoxFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/CheckBoxFactory.java
@@ -2,7 +2,9 @@ package com.vijay.jsonwizard.widgets;
 
 import android.content.Context;
 import android.graphics.Typeface;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,6 +18,8 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 
+import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.JsonFormUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -30,63 +34,117 @@ import static com.vijay.jsonwizard.utils.FormUtils.*;
  */
 public class CheckBoxFactory implements FormWidgetFactory {
 
+    private static final String TAG = "CheckBoxFactory";
+
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject,
+            CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
+            int visualizationMode) throws JSONException {
         List<View> views = null;
-        switch (visualizationMode){
-            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :
-                views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
+        switch (visualizationMode) {
+            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
+                views = getReadOnlyViewsFromJson(context, jsonObject, bundle, resolver);
                 break;
             default:
-                views = getEditableViewsFromJson(context, jsonObject, listener, bundle);
+                views = getEditableViewsFromJson(context, jsonObject, listener, bundle, resolver);
         }
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle) throws JSONException {
+    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject,
+            CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver)
+            throws JSONException {
         List<View> views = new ArrayList<>(1);
-        views.add(getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")), jsonObject.getString("key"),
-                jsonObject.getString("type"), getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0),
+        views.add(getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")),
+                jsonObject.getString("key"),
+                jsonObject.getString("type"),
+                getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0),
                 FONT_BOLD_PATH));
         JSONArray options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
         for (int i = 0; i < options.length(); i++) {
             JSONObject item = options.getJSONObject(i);
-            CheckBox checkBox = (CheckBox) LayoutInflater.from(context).inflate(R.layout.item_checkbox, null);
-            checkBox.setText(bundle.resolveKey(item.getString("text")));
-            checkBox.setTag(R.id.key, jsonObject.getString("key"));
-            checkBox.setTag(R.id.type, jsonObject.getString("type"));
-            checkBox.setTag(R.id.childKey, item.getString("key"));
-            checkBox.setGravity(Gravity.CENTER_VERTICAL);
-            checkBox.setTextSize(16);
-            checkBox.setTypeface(Typeface.createFromAsset(context.getAssets(), FONT_REGULAR_PATH));
-            checkBox.setOnCheckedChangeListener(listener);
-            if (!TextUtils.isEmpty(item.optString("value"))) {
-                checkBox.setChecked(item.optBoolean("value"));
+            if (isVisible(item, context, resolver)) {
+                CheckBox checkBox = (CheckBox) LayoutInflater.from(context)
+                        .inflate(R.layout.item_checkbox, null);
+                checkBox.setText(bundle.resolveKey(item.getString("text")));
+                checkBox.setTag(R.id.key, jsonObject.getString("key"));
+                checkBox.setTag(R.id.type, jsonObject.getString("type"));
+                checkBox.setTag(R.id.childKey, item.getString("key"));
+                checkBox.setGravity(Gravity.CENTER_VERTICAL);
+                checkBox.setTextSize(16);
+                checkBox.setTypeface(
+                        Typeface.createFromAsset(context.getAssets(), FONT_REGULAR_PATH));
+                checkBox.setOnCheckedChangeListener(listener);
+                if (!TextUtils.isEmpty(item.optString("value"))) {
+                    checkBox.setChecked(item.optBoolean("value"));
+                }
+                if (i == options.length() - 1) {
+                    checkBox.setLayoutParams(
+                            getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, (int) context
+                                    .getResources().getDimension(R.dimen.extra_bottom_margin)));
+                }
+                views.add(checkBox);
             }
-            if (i == options.length() - 1) {
-                checkBox.setLayoutParams(getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, (int) context
-                        .getResources().getDimension(R.dimen.extra_bottom_margin)));
-            }
-            views.add(checkBox);
         }
         return views;
     }
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle) throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject,
+            JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
         List<View> views = new ArrayList<>(1);
-        views.add(getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")), jsonObject.getString("key"),
-                jsonObject.getString("type"), getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, (int) context
+        views.add(getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")),
+                jsonObject.getString("key"),
+                jsonObject.getString("type"),
+                getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, (int) context
                         .getResources().getDimension(R.dimen.extra_bottom_margin)),
                 FONT_BOLD_PATH));
         JSONArray options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
         for (int i = 0; i < options.length(); i++) {
             JSONObject item = options.getJSONObject(i);
-            if (!TextUtils.isEmpty(item.optString("value")) && item.optBoolean("value")) {
-                views.add(getTextViewWith(context, 16, bundle.resolveKey(item.getString("text")), item.getString("key"),
-                        null, getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, (int) context
-                                .getResources().getDimension(R.dimen.default_bottom_margin)), FONT_REGULAR_PATH));
+            if (isVisible(item, context, resolver)) {
+                if (!TextUtils.isEmpty(item.optString("value")) && item.optBoolean("value")) {
+                    views.add(
+                            getTextViewWith(context, 16, bundle.resolveKey(item.getString("text")),
+                                    item.getString("key"),
+                                    null, getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0,
+                                            (int) context
+                                                    .getResources()
+                                                    .getDimension(R.dimen.default_bottom_margin)),
+                                    FONT_REGULAR_PATH));
+                }
             }
         }
         return views;
+    }
+
+    private boolean isVisible(JSONObject jsonObject, Context context,
+            JsonExpressionResolver resolver) {
+
+        final String showExpression = jsonObject.optString("show");
+        if (TextUtils.isEmpty(showExpression)) {
+            return true;
+        }
+        if (resolver.isValidExpression(showExpression)) {
+            try {
+                JSONObject currentValues = getCurrentValues(context);
+                return resolver.existsExpression(showExpression, currentValues);
+            } catch (JSONException e) {
+                Log.e(TAG, "isVisible: Error evaluating expression " + showExpression, e);
+            }
+            return false;
+        }
+
+        return ("true".equalsIgnoreCase(showExpression));
+    }
+
+    @Nullable
+    private JSONObject getCurrentValues(Context context) throws JSONException {
+        JSONObject currentValues = null;
+        if (context instanceof JsonApi) {
+            String currentJsonState = ((JsonApi) context).currentJsonState();
+            JSONObject currentJsonObject = new JSONObject(currentJsonState);
+            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
+        }
+        return currentValues;
     }
 }


### PR DESCRIPTION
If the "show" attribute is present in a widget should be evaluated in order to determine whether the widget should be shown or not. 

"show" attribute is also supported in checkbox options

Fix #25 
