### PR TITLE
Add barcode_text widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ android:
     #- extra-google-m2repository
     #- extra-android-m2repository
     #- addon-google_apis-google-19
-    
+
     # Device emulator images
     # - sys-img-armeabi-v7a-google_apis-23
 env:
- global:
-  # install timeout in minutes (2 minutes by default)
-  - ADB_INSTALL_TIMEOUT=8
+  global:
+    # install timeout in minutes (2 minutes by default)
+    - ADB_INSTALL_TIMEOUT=8
 
 # Emulator Management: Create, Start and Wait
 #before_script:
@@ -45,5 +45,5 @@ env:
 # - android-wait-for-emulator
 # - adb shell input keyevent 82 &
 script:
- # By default Travis-ci executes './gradlew build connectedCheck' if no 'script:' section found.
- - ./gradlew :library:sonarqube
+  # By default Travis-ci executes './gradlew build connectedCheck' if no 'script:' section found.
+  - ./gradlew :library:sonarqube

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Not supported yet.
      "key":"selectDate",
      "type":"date_picker",
      "pattern":"dd/MM/yyyy",
-     "hint":"Enter date" 
+     "hint":"Enter date"
 }
 ```
 key - must be unique in that particular step.
@@ -333,6 +333,28 @@ options - EditText included in the EditGroup.
 }
 
 ```
+
+#### Barcode EditText
+```json
+    {
+        "key":"name",
+        "type":"barcode_text",
+        "hint":"Enter Your Name"
+    }
+```
+
+key - must be unique in that particular step.
+
+type - must be barcode_text for Barcode EditText.
+
+hint - hint for Barcode EditText.
+
+lines - number of lines shown by the Barcode EditText
+
+value - will be the value present in the Barcode EditText after completion of wizard
+
+##### Barcode EditText Required Validation
+same as EditText
 
 #### I18n
 ##### Bundle definition
@@ -653,6 +675,25 @@ Step 2. Add the dependency in the form
     <version>1.0</version>
 </dependency>
 ```
+
+##### Barcode Editext usage:
+Barcode uses the MLKit API from Firebase. In order to use it, the following steeps are needed.
+Step 1. Apply google services plugin
+```gradle
+apply plugin: 'com.google.gms.google-services'
+```
+Step 2. Add camera permission
+```xml
+<uses-permission android:name="android.permission.CAMERA"/>
+```
+Step 3. Add the Firebase MLKit vision API key to the app
+Step 4 (Optional). Add metadata to the app Manifest to download the barcode module as soon as the app is installed.
+```xml
+<meta-data
+    android:name="com.google.firebase.ml.vision.DEPENDENCIES"
+    android:value="barcode"/>
+```
+
 # TODOs
 
 - Support validation for Checkbox and RadioButton.

--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,11 @@
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.google.gms:google-services:4.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,10 +17,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@
 # org.gradle.parallel=true
 
 # systemProp.sonar.host.url=http://zuvmljenson01/sonar/
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,15 +1,14 @@
-plugins {
-    id "org.sonarqube" version "2.6.1"
-}
-
+apply plugin: 'org.sonarqube'
 apply plugin: 'com.android.library'
+
+
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.0'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 2
         versionName "1.3.7"
     }
@@ -20,7 +19,7 @@ android {
         }
     }
     lintOptions {
-         abortOnError false
+        abortOnError false
     }
 
     configurations.all {
@@ -31,21 +30,23 @@ android {
         resolutionStrategy.force "com.android.support:support-annotations:$supportLibVersion"
     }
 }
-repositories {
-    maven { url "https://clojars.org/repo/" }
-}
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.github.rey5137:material:1.2.5'
-    compile 'com.rengwuxian.materialedittext:library:2.1.4'
-    compile('com.github.ganfra:material-spinner:1.1.0') {
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    implementation 'com.github.rey5137:material:1.2.5'
+    implementation 'com.rengwuxian.materialedittext:library:2.1.4'
+    implementation('com.github.ganfra:material-spinner:1.1.0') {
         exclude group: 'com.nineoldandroids', module: 'library'
     }
-    compile 'com.jayway.jsonpath:json-path:2.3.0'
-    compile 'com.yarolegovich:discrete-scrollview:1.4.7'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'org.sufficientlysecure:html-textview:3.6'
+    implementation 'com.jayway.jsonpath:json-path:2.3.0'
+    implementation 'com.yarolegovich:discrete-scrollview:1.4.7'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'org.sufficientlysecure:html-textview:3.6'
+
+    implementation 'com.google.firebase:firebase-ml-vision:24.0.0'
+    implementation 'androidx.camera:camera-camera2:1.0.0-alpha02'
+    implementation 'androidx.camera:camera-core:1.0.0-alpha02'
 }
 sonarqube {
     properties {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.vijay.jsonwizard" >
+          package="com.vijay.jsonwizard">
 
     <application>
 
@@ -13,6 +13,8 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths"/>
         </provider>
+
+        <activity android:name=".barcode.LivePreviewActivity" android:exported="true"/>m
 
     </application>
 

--- a/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
+++ b/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
@@ -2,15 +2,15 @@ package com.vijay.jsonwizard.activities;
 
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Surface;
 import android.view.WindowManager;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
@@ -45,19 +45,18 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
     private String externalContentResolverClass;
     private String resourceResolverClass;
 
-    public void init(String json, Integer visualizationMode, String externalContentResolverClass, String resourceResolverClass) {
+    public void init(String json, Integer visualizationMode, String externalContentResolverClass,
+        String resourceResolverClass) {
         this.externalContentResolverClass = externalContentResolverClass;
         this.resourceResolverClass = resourceResolverClass;
         if (!TextUtils.isEmpty(externalContentResolverClass)) {
-            this.mContentResolver = ExternalContentResolverFactory
-                    .getInstance(this, externalContentResolverClass);
+            this.mContentResolver = ExternalContentResolverFactory.getInstance(this, externalContentResolverClass);
         }
 
         if (TextUtils.isEmpty(resourceResolverClass)) {
             this.resourceResolverClass = AssetsResourceResolver.class.getName();
         }
-        this.mResourceResolver = ResourceResolverFactory
-                .getInstance(this, this.resourceResolverClass);
+        this.mResourceResolver = ResourceResolverFactory.getInstance(this, this.resourceResolverClass);
         init(json, visualizationMode);
     }
 
@@ -94,19 +93,16 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
             String contentResolver = getIntent().getStringExtra("resolver");
             String resourceResolver = getIntent().getStringExtra("resourceResolver");
             init(getIntent().getStringExtra("json"), getIntent()
-                    .getIntExtra(JsonFormConstants.VISUALIZATION_MODE_EXTRA,
-                            JsonFormConstants.VISUALIZATION_MODE_EDIT), contentResolver, resourceResolver);
+                    .getIntExtra(JsonFormConstants.VISUALIZATION_MODE_EXTRA, JsonFormConstants.VISUALIZATION_MODE_EDIT),
+                contentResolver, resourceResolver);
             if (mJSONObject != null) {
-                getSupportFragmentManager().beginTransaction()
-                        .add(R.id.container,
-                                JsonFormFragment.getFormFragment(JsonFormConstants.FIRST_STEP_NAME))
-                        .commit();
+                getSupportFragmentManager().beginTransaction().add(R.id.container,
+                    JsonFormFragment.getFormFragment(JsonFormConstants.FIRST_STEP_NAME)).commit();
             }
         } else {
             init(savedInstanceState.getString("jsonState"),
-                    savedInstanceState.getInt(JsonFormConstants.VISUALIZATION_MODE_EXTRA),
-                    savedInstanceState.getString("resolver"),
-                    savedInstanceState.getString("resourceResolver"));
+                savedInstanceState.getInt(JsonFormConstants.VISUALIZATION_MODE_EXTRA),
+                savedInstanceState.getString("resolver"), savedInstanceState.getString("resourceResolver"));
         }
     }
 
@@ -143,9 +139,8 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
     }
 
     @Override
-    public void writeValue(String stepName, String parentKey, String childObjectKey,
-            String childKey, String value)
-            throws JSONException {
+    public void writeValue(String stepName, String parentKey, String childObjectKey, String childKey, String value)
+        throws JSONException {
         synchronized (mJSONObject) {
             JSONObject jsonObject = mJSONObject.getJSONObject(stepName);
             JSONArray fields = jsonObject.getJSONArray("fields");
@@ -258,9 +253,9 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
         boolean hasCurrentOrientationExtra = intent.hasExtra(JsonFormConstants.CURRENT_ORIENTATION_EXTRA);
         int currentOrientation = getResources().getConfiguration().orientation;
 
-        if(hasCurrentOrientationExtra){
-            rotation = getIntent().getIntExtra(JsonFormConstants.CURRENT_ORIENTATION_EXTRA,currentOrientation);
-        }else{
+        if (hasCurrentOrientationExtra) {
+            rotation = getIntent().getIntExtra(JsonFormConstants.CURRENT_ORIENTATION_EXTRA, currentOrientation);
+        } else {
             rotation = this.getWindowManager().getDefaultDisplay().getRotation();
         }
         if (hasOrientationExtra) {
@@ -269,7 +264,7 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
                 if (rotation == Surface.ROTATION_90) {
                     setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
                 } else if (rotation == Surface.ROTATION_270) {
-                    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE );
+                    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
                 }
             } else if (JsonFormConstants.ORIENTATION_PORTRAIT == orientation) {
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/LivePreviewActivity.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/LivePreviewActivity.java
@@ -1,0 +1,339 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
+import android.hardware.Camera;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.Button;
+import android.widget.CompoundButton;
+import android.widget.TextView;
+import android.widget.Toast;
+import android.widget.ToggleButton;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.gms.common.annotation.KeepName;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.ml.vision.FirebaseVision;
+import com.google.firebase.ml.vision.barcode.FirebaseVisionBarcode;
+import com.google.firebase.ml.vision.barcode.FirebaseVisionBarcodeDetector;
+import com.google.firebase.ml.vision.common.FirebaseVisionImage;
+import com.vijay.jsonwizard.R;
+import com.vijay.jsonwizard.barcode.barcodescanning.BarcodeGraphic;
+import com.vijay.jsonwizard.barcode.barcodescanning.BarcodeScanningProcessor;
+import com.vijay.jsonwizard.barcode.common.CameraImageGraphic;
+import com.vijay.jsonwizard.barcode.common.CameraSource;
+import com.vijay.jsonwizard.barcode.common.CameraSourcePreview;
+import com.vijay.jsonwizard.barcode.common.GraphicOverlay;
+import com.vijay.jsonwizard.barcode.common.GraphicOverlay.Graphic;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Demo app showing the various features of ML Kit for Firebase. This class is used to
+ * set up continuous frame processing on frames from a camera source.
+ */
+@KeepName
+public final class LivePreviewActivity extends AppCompatActivity
+    implements OnRequestPermissionsResultCallback, CompoundButton.OnCheckedChangeListener, Button.OnClickListener {
+    private static final String TAG = "LivePreviewActivity";
+    private static final int PERMISSION_REQUESTS = 1;
+    private static final String PARAM_BARCODE = "barcode";
+    private static final String PARAM_ERROR = "error";
+
+    private CameraSource cameraSource = null;
+    private CameraSourcePreview preview;
+    private GraphicOverlay graphicOverlay;
+    private BarcodeScanningProcessor barcodeScanningProcessor;
+    private TextView editText;
+
+    private static boolean isPermissionGranted(Context context, String permission) {
+        if (ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
+            Log.i(TAG, "Permission granted: " + permission);
+            return true;
+        }
+        Log.i(TAG, "Permission NOT granted: " + permission);
+        return false;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.d(TAG, "onCreate");
+        setContentView(R.layout.activity_live_preview);
+        preview = findViewById(R.id.firePreview);
+        if (preview == null) {
+            Log.d(TAG, "Preview is null");
+        }
+        graphicOverlay = findViewById(R.id.fireFaceOverlay);
+        if (graphicOverlay == null) {
+            Log.d(TAG, "graphicOverlay is null");
+        }
+
+        ToggleButton facingSwitch = findViewById(R.id.facingSwitch);
+        facingSwitch.setOnCheckedChangeListener(this);
+
+        final Button submit = findViewById(R.id.submit);
+        submit.setOnClickListener(this);
+
+        editText = findViewById(R.id.selectedCode);
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                submit.setEnabled(true);
+            }
+        });
+
+        // Hide the toggle button if there is only 1 camera
+        if (Camera.getNumberOfCameras() == 1) {
+            facingSwitch.setVisibility(View.GONE);
+        }
+
+        if (allPermissionsGranted()) {
+            isVisionModuleInstalled();
+            createCameraSource();
+
+        } else {
+            getRuntimePermissions();
+        }
+    }
+
+    @Override
+    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        Log.d(TAG, "Set facing");
+        if (cameraSource != null) {
+            if (isChecked) {
+                cameraSource.setFacing(CameraSource.CAMERA_FACING_FRONT);
+            } else {
+                cameraSource.setFacing(CameraSource.CAMERA_FACING_BACK);
+            }
+        }
+        preview.stop();
+        startCameraSource();
+    }
+
+    private void createCameraSource() {
+        // If there's no existing cameraSource, create one.
+        if (cameraSource == null) {
+            cameraSource = new CameraSource(this, graphicOverlay);
+        }
+
+        try {
+
+            Log.i(TAG, "Using Barcode Detector Processor");
+            barcodeScanningProcessor = new BarcodeScanningProcessor();
+            cameraSource.setMachineLearningFrameProcessor(barcodeScanningProcessor);
+
+        } catch (Exception e) {
+            Log.e(TAG, "Can not create image processor: ", e);
+            Toast.makeText(getApplicationContext(), "Can not create image processor: " + e.getMessage(),
+                Toast.LENGTH_LONG).show();
+        }
+    }
+
+    /**
+     * Starts or restarts the camera source, if it exists. If the camera source doesn't exist yet
+     * (e.g., because onResume was called before the camera source was created), this will be called
+     * again when the camera source is created.
+     */
+    private void startCameraSource() {
+        if (cameraSource != null) {
+            try {
+                if (preview == null) {
+                    Log.d(TAG, "resume: Preview is null");
+                }
+                if (graphicOverlay == null) {
+                    Log.d(TAG, "resume: graphOverlay is null");
+                }
+                preview.start(cameraSource, graphicOverlay);
+            } catch (IOException e) {
+                Log.e(TAG, "Unable to start camera source.", e);
+                cameraSource.release();
+                cameraSource = null;
+            }
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        Log.d(TAG, "onResume");
+        startCameraSource();
+    }
+
+    /**
+     * Stops the camera.
+     */
+    @Override
+    protected void onPause() {
+        super.onPause();
+        preview.stop();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (cameraSource != null) {
+            cameraSource.release();
+        }
+    }
+
+    private String[] getRequiredPermissions() {
+        String[] permissions = new String[]{Manifest.permission.CAMERA};
+        return permissions;
+    }
+
+    private boolean allPermissionsGranted() {
+        for (String permission: getRequiredPermissions()) {
+            if (!isPermissionGranted(this, permission)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void getRuntimePermissions() {
+        List<String> allNeededPermissions = new ArrayList<>();
+        for (String permission: getRequiredPermissions()) {
+            if (!isPermissionGranted(this, permission)) {
+                allNeededPermissions.add(permission);
+            }
+        }
+
+        if (!allNeededPermissions.isEmpty()) {
+            ActivityCompat.requestPermissions(this, allNeededPermissions.toArray(new String[0]), PERMISSION_REQUESTS);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, @NonNull int[] grantResults) {
+        Log.i(TAG, "Permission granted!");
+        if (allPermissionsGranted()) {
+            createCameraSource();
+        }
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    private BarcodeGraphic getGraphAtPos(GraphicOverlay overlay, float x, float y) {
+        BarcodeGraphic selected = null;
+        for (Graphic graph: overlay.getGraphics()) {
+            if (graph instanceof BarcodeGraphic) {
+                BarcodeGraphic barcodeGraphic = (BarcodeGraphic) graph;
+
+                if (barcodeGraphic.contains(x, y)) {
+                    Log.d("GraphicOverlay", "getGraphAtPos: winner!");
+                    selected = barcodeGraphic;
+                }
+            }
+        }
+        return selected;
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            Log.d(TAG, "dispatchTouchEvent: event");
+            float x = event.getRawX();
+            float y = event.getRawY();
+
+            int[] coordinates = new int[2];
+            graphicOverlay.getLocationOnScreen(coordinates);
+
+            x -= coordinates[0];
+            y -= coordinates[1];
+
+            BarcodeGraphic graph = getGraphAtPos(graphicOverlay, x, y);
+            if (graph != null) {
+                CameraImageGraphic lastImage = barcodeScanningProcessor.getLastImage();
+                barcodeScanningProcessor.pause();
+                cameraSource.stop();
+                String barcodeValue = graph.getBarcode().getDisplayValue();
+                Log.d(TAG, "dispatchTouchEvent: Selected = " + barcodeValue);
+                graphicOverlay.highlight(graph);
+                refreshOverlay(graphicOverlay, lastImage);
+                editText.setText(barcodeValue);
+            }
+
+        }
+        return super.dispatchTouchEvent(event);
+    }
+
+    private void refreshOverlay(GraphicOverlay overlay, CameraImageGraphic cameraImage) {
+        List<Graphic> graphics = new ArrayList<>(overlay.getGraphics());
+        overlay.clear();
+
+        for (Graphic graphic: graphics) {
+            overlay.add(graphic);
+        }
+        overlay.postInvalidate();
+    }
+
+    @Override
+    public void onClick(View v) {
+        if (v != null && v.getId() == R.id.submit) {
+            Log.d(TAG, "onClick: Submit!!!");
+            Intent result = new Intent();
+            result.putExtra(PARAM_BARCODE, editText.getText().toString());
+            setResult(Activity.RESULT_OK, result);
+            finish();
+        }
+    }
+
+    private void isVisionModuleInstalled() {
+        final Boolean isAvailable = false;
+        FirebaseVisionBarcodeDetector detector = FirebaseVision.getInstance().getVisionBarcodeDetector();
+        int w = 32;
+        int h = 32;
+        Bitmap.Config conf = Bitmap.Config.ARGB_4444; // see other conf types
+        Bitmap bmp = Bitmap.createBitmap(w, h, conf);
+        Task<List<FirebaseVisionBarcode>> task = detector.detectInImage(FirebaseVisionImage.fromBitmap(bmp));
+        task.addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                Log.d(TAG, "onCreate: wait for install");
+                Intent result = new Intent();
+                result.putExtra(PARAM_ERROR, "");
+                setResult(Activity.RESULT_OK, result);
+                finish();
+            }
+        });
+
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/VisionProcessorBase.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/VisionProcessorBase.java
@@ -1,0 +1,135 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode;
+
+import android.graphics.Bitmap;
+
+import androidx.annotation.GuardedBy;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.ml.vision.common.FirebaseVisionImage;
+import com.google.firebase.ml.vision.common.FirebaseVisionImageMetadata;
+import com.vijay.jsonwizard.barcode.common.BitmapUtils;
+import com.vijay.jsonwizard.barcode.common.FrameMetadata;
+import com.vijay.jsonwizard.barcode.common.GraphicOverlay;
+import com.vijay.jsonwizard.barcode.common.VisionImageProcessor;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Abstract base class for ML Kit frame processors. Subclasses need to implement {@link
+ * #onSuccess(Bitmap, Object, FrameMetadata, GraphicOverlay)} to define what they want to with
+ * the detection results and {@link #detectInImage(FirebaseVisionImage)} to specify the detector
+ * object.
+ *
+ * @param <T> The type of the detected feature.
+ */
+public abstract class VisionProcessorBase<T> implements VisionImageProcessor {
+
+    // To keep the latest images and its metadata.
+    @GuardedBy("this")
+    private ByteBuffer latestImage;
+
+    @GuardedBy("this")
+    private FrameMetadata latestImageMetaData;
+
+    // To keep the images and metadata in process.
+    @GuardedBy("this")
+    private ByteBuffer processingImage;
+
+    @GuardedBy("this")
+
+    private FrameMetadata processingMetaData;
+
+    private boolean paused = false;
+
+    public VisionProcessorBase() {
+    }
+
+    @Override
+    public synchronized void process(ByteBuffer data, final FrameMetadata frameMetadata,
+        final GraphicOverlay graphicOverlay) {
+        latestImage = data;
+        latestImageMetaData = frameMetadata;
+        if (processingImage == null && processingMetaData == null) {
+            processLatestImage(graphicOverlay);
+        }
+    }
+
+    // Bitmap version
+    @Override
+    public void process(Bitmap bitmap, final GraphicOverlay graphicOverlay) {
+        detectInVisionImage(null /* bitmap */, FirebaseVisionImage.fromBitmap(bitmap), null, graphicOverlay);
+    }
+
+    private synchronized void processLatestImage(final GraphicOverlay graphicOverlay) {
+        processingImage = latestImage;
+        processingMetaData = latestImageMetaData;
+        latestImage = null;
+        latestImageMetaData = null;
+        if (processingImage != null && processingMetaData != null) {
+            processImage(processingImage, processingMetaData, graphicOverlay);
+        }
+    }
+
+    private void processImage(ByteBuffer data, final FrameMetadata frameMetadata, final GraphicOverlay graphicOverlay) {
+        FirebaseVisionImageMetadata metadata = new FirebaseVisionImageMetadata.Builder().setFormat(
+            FirebaseVisionImageMetadata.IMAGE_FORMAT_NV21).setWidth(frameMetadata.getWidth()).setHeight(
+            frameMetadata.getHeight()).setRotation(frameMetadata.getRotation()).build();
+
+        Bitmap bitmap = BitmapUtils.getBitmap(data, frameMetadata);
+        detectInVisionImage(bitmap, FirebaseVisionImage.fromByteBuffer(data, metadata), frameMetadata, graphicOverlay);
+    }
+
+    private void detectInVisionImage(final Bitmap originalCameraImage, FirebaseVisionImage image,
+        final FrameMetadata metadata, final GraphicOverlay graphicOverlay) {
+        detectInImage(image).addOnSuccessListener(new OnSuccessListener<T>() {
+            @Override
+            public void onSuccess(T results) {
+                VisionProcessorBase.this.onSuccess(originalCameraImage, results, metadata, graphicOverlay);
+                processLatestImage(graphicOverlay);
+            }
+        }).addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                VisionProcessorBase.this.onFailure(e);
+            }
+        });
+    }
+
+    @Override
+    public void pause() {
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    protected abstract Task<T> detectInImage(FirebaseVisionImage image);
+
+    /**
+     * Callback that executes with a successful detection result.
+     *
+     * @param originalCameraImage hold the original image from camera, used to draw the background
+     *     image.
+     */
+    protected abstract void onSuccess(@Nullable Bitmap originalCameraImage, @NonNull T results,
+        @NonNull FrameMetadata frameMetadata, @NonNull GraphicOverlay graphicOverlay);
+
+    protected abstract void onFailure(@NonNull Exception e);
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/barcodescanning/BarcodeGraphic.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/barcodescanning/BarcodeGraphic.java
@@ -1,0 +1,108 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode.barcodescanning;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.RectF;
+
+import com.google.firebase.ml.vision.barcode.FirebaseVisionBarcode;
+import com.vijay.jsonwizard.barcode.common.GraphicOverlay;
+import com.vijay.jsonwizard.barcode.common.GraphicOverlay.Graphic;
+
+/** Graphic instance for rendering Barcode position and content information in an overlay view. */
+public class BarcodeGraphic extends Graphic {
+
+    private static final int TEXT_COLOR = Color.WHITE;
+    private static final float TEXT_SIZE = 54.0f;
+    private static final float STROKE_WIDTH = 4.0f;
+
+    private final Paint rectPaint;
+    private final Paint barcodePaint;
+    private final FirebaseVisionBarcode barcode;
+    private RectF rect;
+    private Rect textRect;
+
+    BarcodeGraphic(GraphicOverlay overlay, FirebaseVisionBarcode barcode) {
+        super(overlay);
+
+        this.barcode = barcode;
+
+        rectPaint = new Paint();
+        rectPaint.setColor(TEXT_COLOR);
+        rectPaint.setStyle(Paint.Style.STROKE);
+        rectPaint.setStrokeWidth(STROKE_WIDTH);
+
+        barcodePaint = new Paint();
+        barcodePaint.setColor(TEXT_COLOR);
+        barcodePaint.setTextSize(TEXT_SIZE);
+
+        rect = new RectF(barcode.getBoundingBox());
+        rect.left = translateX(rect.left);
+        rect.top = translateY(rect.top);
+        rect.right = translateX(rect.right);
+        rect.bottom = translateY(rect.bottom);
+
+        textRect = new Rect();
+    }
+
+    /**
+     * Draws the barcode block annotations for position, size, and raw value on the supplied canvas.
+     */
+    @Override
+    public void draw(Canvas canvas) {
+        if (barcode == null) {
+            throw new IllegalStateException("Attempting to draw a null barcode.");
+        }
+
+        // Draws the bounding box around the BarcodeBlock.
+
+        canvas.drawRect(rect, rectPaint);
+
+        // Renders the barcode at the bottom of the box.
+        String text = barcode.getRawValue();
+
+        //Text bounds to make them clickable too
+        barcodePaint.getTextBounds(text, 0, text.length(), textRect);
+        textRect.left += rect.left;
+        textRect.right += rect.left;
+        textRect.top += rect.bottom;
+        textRect.bottom += rect.bottom;
+        //To draw text bounds
+        //canvas.drawRect(textRect, rectPaint);
+
+        canvas.drawText(text, rect.left, rect.bottom, barcodePaint);
+
+    }
+
+    public void removeHighlight() {
+        this.rectPaint.setColor(TEXT_COLOR);
+        this.barcodePaint.setColor(TEXT_COLOR);
+    }
+
+    public void highlight() {
+        this.rectPaint.setColor(Color.RED);
+        this.barcodePaint.setColor(Color.RED);
+    }
+
+    public FirebaseVisionBarcode getBarcode() {
+        return this.barcode;
+    }
+
+    public boolean contains(float x, float y) {
+        return (rect.contains(x, y) || (textRect.contains((int) x, (int) y)));
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/barcodescanning/BarcodeScanningProcessor.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/barcodescanning/BarcodeScanningProcessor.java
@@ -1,0 +1,109 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode.barcodescanning;
+
+import android.graphics.Bitmap;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.ml.common.FirebaseMLException;
+import com.google.firebase.ml.vision.FirebaseVision;
+import com.google.firebase.ml.vision.barcode.FirebaseVisionBarcode;
+import com.google.firebase.ml.vision.barcode.FirebaseVisionBarcodeDetector;
+import com.google.firebase.ml.vision.common.FirebaseVisionImage;
+import com.vijay.jsonwizard.barcode.VisionProcessorBase;
+import com.vijay.jsonwizard.barcode.common.CameraImageGraphic;
+import com.vijay.jsonwizard.barcode.common.FrameMetadata;
+import com.vijay.jsonwizard.barcode.common.GraphicOverlay;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Barcode Detector Demo.
+ */
+public class BarcodeScanningProcessor extends VisionProcessorBase<List<FirebaseVisionBarcode>> {
+
+    private static final String TAG = "BarcodeScanProc";
+
+    private final FirebaseVisionBarcodeDetector detector;
+    private boolean pause = false;
+    private CameraImageGraphic lastImage = null;
+
+    public BarcodeScanningProcessor() {
+        // Note that if you know which format of barcode your app is dealing with, detection will be
+        // faster to specify the supported barcode formats one by one, e.g.
+        // new FirebaseVisionBarcodeDetectorOptions.Builder()
+        //     .setBarcodeFormats(FirebaseVisionBarcode.FORMAT_QR_CODE)
+        //     .build();
+        detector = FirebaseVision.getInstance().getVisionBarcodeDetector();
+    }
+
+    @Override
+    public void stop() {
+        try {
+            detector.close();
+        } catch (IOException e) {
+            Log.e(TAG, "Exception thrown while trying to close Barcode Detector: " + e);
+        }
+    }
+
+    @Override
+    protected Task<List<FirebaseVisionBarcode>> detectInImage(FirebaseVisionImage image) {
+        return detector.detectInImage(image);
+    }
+
+    @Override
+    protected void onSuccess(@Nullable Bitmap originalCameraImage, @NonNull List<FirebaseVisionBarcode> barcodes,
+        @NonNull FrameMetadata frameMetadata, @NonNull GraphicOverlay graphicOverlay) {
+        if (!pause) {
+            graphicOverlay.clear();
+            if (originalCameraImage != null) {
+                CameraImageGraphic imageGraphic = new CameraImageGraphic(graphicOverlay, originalCameraImage);
+                graphicOverlay.add(imageGraphic);
+                lastImage = imageGraphic;
+            }
+            for (int i = 0; i < barcodes.size(); ++i) {
+                FirebaseVisionBarcode barcode = barcodes.get(i);
+                BarcodeGraphic barcodeGraphic = new BarcodeGraphic(graphicOverlay, barcode);
+                graphicOverlay.add(barcodeGraphic);
+            }
+        }
+        graphicOverlay.postInvalidate();
+    }
+
+    @Override
+    protected void onFailure(@NonNull Exception e) {
+        if (e instanceof FirebaseMLException) {
+            FirebaseMLException mle = (FirebaseMLException) e;
+            if (mle.getCode() == FirebaseMLException.UNAVAILABLE) {
+                //Have to wait for download
+
+            }
+        }
+        Log.e(TAG, "Barcode detection failed " + e);
+    }
+
+    public void pause() {
+        this.pause = true;
+    }
+
+    public CameraImageGraphic getLastImage() {
+        return this.lastImage;
+    }
+
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/common/BitmapUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/common/BitmapUtils.java
@@ -1,0 +1,75 @@
+package com.vijay.jsonwizard.barcode.common;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.ImageFormat;
+import android.graphics.Matrix;
+import android.graphics.Rect;
+import android.graphics.YuvImage;
+import android.hardware.Camera.CameraInfo;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.google.firebase.ml.vision.common.FirebaseVisionImageMetadata;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+/** Utils functions for bitmap conversions. */
+public class BitmapUtils {
+
+    // Convert NV21 format byte buffer to bitmap.
+    @Nullable
+    public static Bitmap getBitmap(ByteBuffer data, FrameMetadata metadata) {
+        data.rewind();
+        byte[] imageInBuffer = new byte[data.limit()];
+        data.get(imageInBuffer, 0, imageInBuffer.length);
+        try {
+            YuvImage image = new YuvImage(imageInBuffer, ImageFormat.NV21, metadata.getWidth(), metadata.getHeight(),
+                null);
+            if (image != null) {
+                ByteArrayOutputStream stream = new ByteArrayOutputStream();
+                image.compressToJpeg(new Rect(0, 0, metadata.getWidth(), metadata.getHeight()), 80, stream);
+
+                Bitmap bmp = BitmapFactory.decodeByteArray(stream.toByteArray(), 0, stream.size());
+
+                stream.close();
+                return rotateBitmap(bmp, metadata.getRotation(), metadata.getCameraFacing());
+            }
+        } catch (Exception e) {
+            Log.e("VisionProcessorBase", "Error: " + e.getMessage());
+        }
+        return null;
+    }
+
+    // Rotates a bitmap if it is converted from a bytebuffer.
+    private static Bitmap rotateBitmap(Bitmap bitmap, int rotation, int facing) {
+        Matrix matrix = new Matrix();
+        int rotationDegree = 0;
+        switch (rotation) {
+            case FirebaseVisionImageMetadata.ROTATION_90:
+                rotationDegree = 90;
+                break;
+            case FirebaseVisionImageMetadata.ROTATION_180:
+                rotationDegree = 180;
+                break;
+            case FirebaseVisionImageMetadata.ROTATION_270:
+                rotationDegree = 270;
+                break;
+            default:
+                break;
+        }
+
+        // Rotate the image back to straight.}
+        matrix.postRotate(rotationDegree);
+        if (facing == CameraInfo.CAMERA_FACING_BACK) {
+            return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+        } else {
+            // Mirror the image along X axis for front-facing camera image.
+            matrix.postScale(-1.0f, 1.0f);
+            return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+        }
+    }
+}
+

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/common/CameraImageGraphic.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/common/CameraImageGraphic.java
@@ -1,0 +1,24 @@
+package com.vijay.jsonwizard.barcode.common;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+
+import com.vijay.jsonwizard.barcode.common.GraphicOverlay.Graphic;
+
+/** Draw camera image to background. */
+public class CameraImageGraphic extends Graphic {
+
+    private final Bitmap bitmap;
+
+    public CameraImageGraphic(GraphicOverlay overlay, Bitmap bitmap) {
+        super(overlay);
+        this.bitmap = bitmap;
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        canvas.drawBitmap(bitmap, null, new Rect(0, 0, canvas.getWidth(), canvas.getHeight()), null);
+    }
+}
+

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/common/CameraSource.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/common/CameraSource.java
@@ -1,0 +1,713 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.vijay.jsonwizard.barcode.common;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.ImageFormat;
+import android.graphics.SurfaceTexture;
+import android.hardware.Camera;
+import android.hardware.Camera.CameraInfo;
+import android.util.Log;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import android.view.WindowManager;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+
+import com.google.android.gms.common.images.Size;
+
+import java.io.IOException;
+import java.lang.Thread.State;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Manages the camera and allows UI updates on top of it (e.g. overlaying extra Graphics or
+ * displaying extra information). This receives preview frames from the camera at a specified rate,
+ * sending those frames to child classes' detectors / classifiers as fast as it is able to process.
+ */
+@SuppressLint("MissingPermission")
+public class CameraSource {
+    @SuppressLint("InlinedApi")
+    public static final int CAMERA_FACING_BACK = CameraInfo.CAMERA_FACING_BACK;
+
+    @SuppressLint("InlinedApi")
+    public static final int CAMERA_FACING_FRONT = CameraInfo.CAMERA_FACING_FRONT;
+
+    private static final String TAG = "MIDemoApp:CameraSource";
+
+    /**
+     * The dummy surface texture must be assigned a chosen name. Since we never use an OpenGL context,
+     * we can choose any ID we want here. The dummy surface texture is not a crazy hack - it is
+     * actually how the camera team recommends using the camera without a preview.
+     */
+    private static final int DUMMY_TEXTURE_NAME = 100;
+
+    /**
+     * If the absolute difference between a preview size aspect ratio and a picture size aspect ratio
+     * is less than this tolerance, they are considered to be the same aspect ratio.
+     */
+    private static final float ASPECT_RATIO_TOLERANCE = 0.01f;
+    // These values may be requested by the caller.  Due to hardware limitations, we may need to
+    // select close, but not exactly the same values for these.
+    private final float requestedFps = 20.0f;
+    private final int requestedPreviewWidth = 960;
+    private final int requestedPreviewHeight = 720;
+    private final boolean requestedAutoFocus = true;
+    private final GraphicOverlay graphicOverlay;
+    private final FrameProcessingRunnable processingRunnable;
+    private final Object processorLock = new Object();
+    /**
+     * Map to convert between a byte array, received from the camera, and its associated byte buffer.
+     * We use byte buffers internally because this is a more efficient way to call into native code
+     * later (avoids a potential copy).
+     *
+     * <p><b>Note:</b> uses IdentityHashMap here instead of HashMap because the behavior of an array's
+     * equals, hashCode and toString methods is both useless and unexpected. IdentityHashMap enforces
+     * identity ('==') check on the keys.
+     */
+    private final Map<byte[], ByteBuffer> bytesToByteBuffer = new IdentityHashMap<>();
+    protected Activity activity;
+    protected int facing = CAMERA_FACING_BACK;
+    private Camera camera;
+    /**
+     * Rotation of the device, and thus the associated preview images captured from the device. See
+     * Frame.Metadata#getRotation().
+     */
+    private int rotation;
+    private Size previewSize;
+    // These instances need to be held onto to avoid GC of their underlying resources.  Even though
+    // these aren't used outside of the method that creates them, they still must have hard
+    // references maintained to them.
+    private SurfaceTexture dummySurfaceTexture;
+    // True if a SurfaceTexture is being used for the preview, false if a SurfaceHolder is being
+    // used for the preview.  We want to be compatible back to Gingerbread, but SurfaceTexture
+    // wasn't introduced until Honeycomb.  Since the interface cannot use a SurfaceTexture, if the
+    // developer wants to display a preview we must use a SurfaceHolder.  If the developer doesn't
+    // want to display a preview we use a SurfaceTexture if we are running at least Honeycomb.
+    private boolean usingSurfaceTexture;
+    /**
+     * Dedicated thread and associated runnable for calling into the detector with frames, as the
+     * frames become available from the camera.
+     */
+    private Thread processingThread;
+    // @GuardedBy("processorLock")
+    private VisionImageProcessor frameProcessor;
+
+    public CameraSource(Activity activity, GraphicOverlay overlay) {
+        this.activity = activity;
+        graphicOverlay = overlay;
+        graphicOverlay.clear();
+        processingRunnable = new FrameProcessingRunnable();
+
+        if (Camera.getNumberOfCameras() == 1) {
+            CameraInfo cameraInfo = new CameraInfo();
+            Camera.getCameraInfo(0, cameraInfo);
+            facing = cameraInfo.facing;
+        }
+    }
+
+    // ==============================================================================================
+    // Public
+    // ==============================================================================================
+
+    /**
+     * Gets the id for the camera specified by the direction it is facing. Returns -1 if no such
+     * camera was found.
+     *
+     * @param facing the desired camera (front-facing or rear-facing)
+     */
+    private static int getIdForRequestedCamera(int facing) {
+        CameraInfo cameraInfo = new CameraInfo();
+        for (int i = 0; i < Camera.getNumberOfCameras(); ++i) {
+            Camera.getCameraInfo(i, cameraInfo);
+            if (cameraInfo.facing == facing) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Selects the most suitable preview and picture size, given the desired width and height.
+     *
+     * <p>Even though we only need to find the preview size, it's necessary to find both the preview
+     * size and the picture size of the camera together, because these need to have the same aspect
+     * ratio. On some hardware, if you would only set the preview size, you will get a distorted
+     * image.
+     *
+     * @param camera the camera to select a preview size from
+     * @param desiredWidth the desired width of the camera preview frames
+     * @param desiredHeight the desired height of the camera preview frames
+     * @return the selected preview and picture size pair
+     */
+    private static SizePair selectSizePair(Camera camera, int desiredWidth, int desiredHeight) {
+        List<SizePair> validPreviewSizes = generateValidPreviewSizeList(camera);
+
+        // The method for selecting the best size is to minimize the sum of the differences between
+        // the desired values and the actual values for width and height.  This is certainly not the
+        // only way to select the best size, but it provides a decent tradeoff between using the
+        // closest aspect ratio vs. using the closest pixel area.
+        SizePair selectedPair = null;
+        int minDiff = Integer.MAX_VALUE;
+        for (SizePair sizePair: validPreviewSizes) {
+            Size size = sizePair.previewSize();
+            int diff = Math.abs(size.getWidth() - desiredWidth) + Math.abs(size.getHeight() - desiredHeight);
+            if (diff < minDiff) {
+                selectedPair = sizePair;
+                minDiff = diff;
+            }
+        }
+
+        return selectedPair;
+    }
+
+    /**
+     * Generates a list of acceptable preview sizes. Preview sizes are not acceptable if there is not
+     * a corresponding picture size of the same aspect ratio. If there is a corresponding picture size
+     * of the same aspect ratio, the picture size is paired up with the preview size.
+     *
+     * <p>This is necessary because even if we don't use still pictures, the still picture size must
+     * be set to a size that is the same aspect ratio as the preview size we choose. Otherwise, the
+     * preview images may be distorted on some devices.
+     */
+    private static List<SizePair> generateValidPreviewSizeList(Camera camera) {
+        Camera.Parameters parameters = camera.getParameters();
+        List<Camera.Size> supportedPreviewSizes = parameters.getSupportedPreviewSizes();
+        List<Camera.Size> supportedPictureSizes = parameters.getSupportedPictureSizes();
+        List<SizePair> validPreviewSizes = new ArrayList<>();
+        for (Camera.Size previewSize: supportedPreviewSizes) {
+            float previewAspectRatio = (float) previewSize.width / (float) previewSize.height;
+
+            // By looping through the picture sizes in order, we favor the higher resolutions.
+            // We choose the highest resolution in order to support taking the full resolution
+            // picture later.
+            for (Camera.Size pictureSize: supportedPictureSizes) {
+                float pictureAspectRatio = (float) pictureSize.width / (float) pictureSize.height;
+                if (Math.abs(previewAspectRatio - pictureAspectRatio) < ASPECT_RATIO_TOLERANCE) {
+                    validPreviewSizes.add(new SizePair(previewSize, pictureSize));
+                    break;
+                }
+            }
+        }
+
+        // If there are no picture sizes with the same aspect ratio as any preview sizes, allow all
+        // of the preview sizes and hope that the camera can handle it.  Probably unlikely, but we
+        // still account for it.
+        if (validPreviewSizes.size() == 0) {
+            Log.w(TAG, "No preview sizes have a corresponding same-aspect-ratio picture size");
+            for (Camera.Size previewSize: supportedPreviewSizes) {
+                // The null picture size will let us know that we shouldn't set a picture size.
+                validPreviewSizes.add(new SizePair(previewSize, null));
+            }
+        }
+
+        return validPreviewSizes;
+    }
+
+    /**
+     * Selects the most suitable preview frames per second range, given the desired frames per second.
+     *
+     * @param camera the camera to select a frames per second range from
+     * @param desiredPreviewFps the desired frames per second for the camera preview frames
+     * @return the selected preview frames per second range
+     */
+    @SuppressLint("InlinedApi")
+    private static int[] selectPreviewFpsRange(Camera camera, float desiredPreviewFps) {
+        // The camera API uses integers scaled by a factor of 1000 instead of floating-point frame
+        // rates.
+        int desiredPreviewFpsScaled = (int) (desiredPreviewFps * 1000.0f);
+
+        // The method for selecting the best range is to minimize the sum of the differences between
+        // the desired value and the upper and lower bounds of the range.  This may select a range
+        // that the desired value is outside of, but this is often preferred.  For example, if the
+        // desired frame rate is 29.97, the range (30, 30) is probably more desirable than the
+        // range (15, 30).
+        int[] selectedFpsRange = null;
+        int minDiff = Integer.MAX_VALUE;
+        List<int[]> previewFpsRangeList = camera.getParameters().getSupportedPreviewFpsRange();
+        for (int[] range: previewFpsRangeList) {
+            int deltaMin = desiredPreviewFpsScaled - range[Camera.Parameters.PREVIEW_FPS_MIN_INDEX];
+            int deltaMax = desiredPreviewFpsScaled - range[Camera.Parameters.PREVIEW_FPS_MAX_INDEX];
+            int diff = Math.abs(deltaMin) + Math.abs(deltaMax);
+            if (diff < minDiff) {
+                selectedFpsRange = range;
+                minDiff = diff;
+            }
+        }
+        return selectedFpsRange;
+    }
+
+    /** Stops the camera and releases the resources of the camera and underlying detector. */
+    public void release() {
+        synchronized (processorLock) {
+            stop();
+            processingRunnable.release();
+            cleanScreen();
+
+            if (frameProcessor != null) {
+                frameProcessor.stop();
+            }
+        }
+    }
+
+    /**
+     * Opens the camera and starts sending preview frames to the underlying detector. The preview
+     * frames are not displayed.
+     *
+     * @throws IOException if the camera's preview texture or display could not be initialized
+     */
+    @SuppressLint("MissingPermission")
+    @RequiresPermission(Manifest.permission.CAMERA)
+    public synchronized CameraSource start() throws IOException {
+        if (camera != null) {
+            return this;
+        }
+
+        camera = createCamera();
+        dummySurfaceTexture = new SurfaceTexture(DUMMY_TEXTURE_NAME);
+        camera.setPreviewTexture(dummySurfaceTexture);
+        usingSurfaceTexture = true;
+        camera.startPreview();
+
+        processingThread = new Thread(processingRunnable);
+        processingRunnable.setActive(true);
+        processingThread.start();
+        return this;
+    }
+
+    /**
+     * Opens the camera and starts sending preview frames to the underlying detector. The supplied
+     * surface holder is used for the preview so frames can be displayed to the user.
+     *
+     * @param surfaceHolder the surface holder to use for the preview frames
+     * @throws IOException if the supplied surface holder could not be used as the preview display
+     */
+    @RequiresPermission(Manifest.permission.CAMERA)
+    public synchronized CameraSource start(SurfaceHolder surfaceHolder) throws IOException {
+        if (camera != null) {
+            return this;
+        }
+
+        camera = createCamera();
+        camera.setPreviewDisplay(surfaceHolder);
+        camera.startPreview();
+
+        processingThread = new Thread(processingRunnable);
+        processingRunnable.setActive(true);
+        processingThread.start();
+
+        usingSurfaceTexture = false;
+        return this;
+    }
+
+    /**
+     * Closes the camera and stops sending frames to the underlying frame detector.
+     *
+     * <p>This camera source may be restarted again by calling {@link #start()} or {@link
+     * #start(SurfaceHolder)}.
+     *
+     * <p>Call {@link #release()} instead to completely shut down this camera source and release the
+     * resources of the underlying detector.
+     */
+    public synchronized void stop() {
+        processingRunnable.setActive(false);
+        if (processingThread != null) {
+            try {
+                // Wait for the thread to complete to ensure that we can't have multiple threads
+                // executing at the same time (i.e., which would happen if we called start too
+                // quickly after stop).
+                processingThread.join();
+            } catch (InterruptedException e) {
+                Log.d(TAG, "Frame processing thread interrupted on release.");
+            }
+            processingThread = null;
+        }
+
+        if (camera != null) {
+            camera.stopPreview();
+            camera.setPreviewCallbackWithBuffer(null);
+            try {
+                if (usingSurfaceTexture) {
+                    camera.setPreviewTexture(null);
+                } else {
+                    camera.setPreviewDisplay(null);
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to clear camera preview: " + e);
+            }
+            camera.release();
+            camera = null;
+        }
+
+        // Release the reference to any image buffers, since these will no longer be in use.
+        bytesToByteBuffer.clear();
+    }
+
+    /** Changes the facing of the camera. */
+    public synchronized void setFacing(int facing) {
+        if ((facing != CAMERA_FACING_BACK) && (facing != CAMERA_FACING_FRONT)) {
+            throw new IllegalArgumentException("Invalid camera: " + facing);
+        }
+        this.facing = facing;
+    }
+
+    /** Returns the preview size that is currently in use by the underlying camera. */
+    public Size getPreviewSize() {
+        return previewSize;
+    }
+
+    /**
+     * Returns the selected camera; one of {@link #CAMERA_FACING_BACK} or {@link
+     * #CAMERA_FACING_FRONT}.
+     */
+    public int getCameraFacing() {
+        return facing;
+    }
+
+    /**
+     * Opens the camera and applies the user settings.
+     *
+     * @throws IOException if camera cannot be found or preview cannot be processed
+     */
+    @SuppressLint("InlinedApi")
+    private Camera createCamera() throws IOException {
+        int requestedCameraId = getIdForRequestedCamera(facing);
+        if (requestedCameraId == -1) {
+            throw new IOException("Could not find requested camera.");
+        }
+        Camera camera = Camera.open(requestedCameraId);
+
+        SizePair sizePair = selectSizePair(camera, requestedPreviewWidth, requestedPreviewHeight);
+        if (sizePair == null) {
+            throw new IOException("Could not find suitable preview size.");
+        }
+        Size pictureSize = sizePair.pictureSize();
+        previewSize = sizePair.previewSize();
+
+        int[] previewFpsRange = selectPreviewFpsRange(camera, requestedFps);
+        if (previewFpsRange == null) {
+            throw new IOException("Could not find suitable preview frames per second range.");
+        }
+
+        Camera.Parameters parameters = camera.getParameters();
+
+        if (pictureSize != null) {
+            parameters.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
+        }
+        parameters.setPreviewSize(previewSize.getWidth(), previewSize.getHeight());
+        parameters.setPreviewFpsRange(previewFpsRange[Camera.Parameters.PREVIEW_FPS_MIN_INDEX],
+            previewFpsRange[Camera.Parameters.PREVIEW_FPS_MAX_INDEX]);
+        parameters.setPreviewFormat(ImageFormat.NV21);
+
+        setRotation(camera, parameters, requestedCameraId);
+
+        if (requestedAutoFocus) {
+            if (parameters.getSupportedFocusModes().contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO)) {
+                parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO);
+            } else {
+                Log.i(TAG, "Camera auto focus is not supported on this device.");
+            }
+        }
+
+        camera.setParameters(parameters);
+
+        // Four frame buffers are needed for working with the camera:
+        //
+        //   one for the frame that is currently being executed upon in doing detection
+        //   one for the next pending frame to process immediately upon completing detection
+        //   two for the frames that the camera uses to populate future preview images
+        //
+        // Through trial and error it appears that two free buffers, in addition to the two buffers
+        // used in this code, are needed for the camera to work properly.  Perhaps the camera has
+        // one thread for acquiring images, and another thread for calling into user code.  If only
+        // three buffers are used, then the camera will spew thousands of warning messages when
+        // detection takes a non-trivial amount of time.
+        camera.setPreviewCallbackWithBuffer(new CameraPreviewCallback());
+        camera.addCallbackBuffer(createPreviewBuffer(previewSize));
+        camera.addCallbackBuffer(createPreviewBuffer(previewSize));
+        camera.addCallbackBuffer(createPreviewBuffer(previewSize));
+        camera.addCallbackBuffer(createPreviewBuffer(previewSize));
+
+        return camera;
+    }
+
+    /**
+     * Calculates the correct rotation for the given camera id and sets the rotation in the
+     * parameters. It also sets the camera's display orientation and rotation.
+     *
+     * @param parameters the camera parameters for which to set the rotation
+     * @param cameraId the camera id to set rotation based on
+     */
+    private void setRotation(Camera camera, Camera.Parameters parameters, int cameraId) {
+        WindowManager windowManager = (WindowManager) activity.getSystemService(Context.WINDOW_SERVICE);
+        int degrees = 0;
+        int rotation = windowManager.getDefaultDisplay().getRotation();
+        switch (rotation) {
+            case Surface.ROTATION_0:
+                degrees = 0;
+                break;
+            case Surface.ROTATION_90:
+                degrees = 90;
+                break;
+            case Surface.ROTATION_180:
+                degrees = 180;
+                break;
+            case Surface.ROTATION_270:
+                degrees = 270;
+                break;
+            default:
+                Log.e(TAG, "Bad rotation value: " + rotation);
+        }
+
+        CameraInfo cameraInfo = new CameraInfo();
+        Camera.getCameraInfo(cameraId, cameraInfo);
+
+        int angle;
+        int displayAngle;
+        if (cameraInfo.facing == CameraInfo.CAMERA_FACING_FRONT) {
+            angle = (cameraInfo.orientation + degrees) % 360;
+            displayAngle = (360 - angle) % 360; // compensate for it being mirrored
+        } else { // back-facing
+            angle = (cameraInfo.orientation - degrees + 360) % 360;
+            displayAngle = angle;
+        }
+
+        // This corresponds to the rotation constants.
+        this.rotation = angle / 90;
+
+        camera.setDisplayOrientation(displayAngle);
+        parameters.setRotation(angle);
+    }
+
+    /**
+     * Creates one buffer for the camera preview callback. The size of the buffer is based off of the
+     * camera preview size and the format of the camera image.
+     *
+     * @return a new preview buffer of the appropriate size for the current camera settings
+     */
+    @SuppressLint("InlinedApi")
+    private byte[] createPreviewBuffer(Size previewSize) {
+        int bitsPerPixel = ImageFormat.getBitsPerPixel(ImageFormat.NV21);
+        long sizeInBits = (long) previewSize.getHeight() * previewSize.getWidth() * bitsPerPixel;
+        int bufferSize = (int) Math.ceil(sizeInBits / 8.0d) + 1;
+
+        // Creating the byte array this way and wrapping it, as opposed to using .allocate(),
+        // should guarantee that there will be an array to work with.
+        byte[] byteArray = new byte[bufferSize];
+        ByteBuffer buffer = ByteBuffer.wrap(byteArray);
+        if (!buffer.hasArray() || (buffer.array() != byteArray)) {
+            // I don't think that this will ever happen.  But if it does, then we wouldn't be
+            // passing the preview content to the underlying detector later.
+            throw new IllegalStateException("Failed to create valid buffer for camera source.");
+        }
+
+        bytesToByteBuffer.put(byteArray, buffer);
+        return byteArray;
+    }
+
+    public void setMachineLearningFrameProcessor(VisionImageProcessor processor) {
+        synchronized (processorLock) {
+            cleanScreen();
+            if (frameProcessor != null) {
+                frameProcessor.stop();
+            }
+            frameProcessor = processor;
+        }
+    }
+
+    // ==============================================================================================
+    // Frame processing
+    // ==============================================================================================
+
+    /** Cleans up graphicOverlay and child classes can do their cleanups as well . */
+    private void cleanScreen() {
+        graphicOverlay.clear();
+    }
+
+    /**
+     * Stores a preview size and a corresponding same-aspect-ratio picture size. To avoid distorted
+     * preview images on some devices, the picture size must be set to a size that is the same aspect
+     * ratio as the preview size or the preview may end up being distorted. If the picture size is
+     * null, then there is no picture size with the same aspect ratio as the preview size.
+     */
+    private static class SizePair {
+        private final Size preview;
+        private Size picture;
+
+        SizePair(Camera.Size previewSize, @Nullable Camera.Size pictureSize) {
+            preview = new Size(previewSize.width, previewSize.height);
+            if (pictureSize != null) {
+                picture = new Size(pictureSize.width, pictureSize.height);
+            }
+        }
+
+        Size previewSize() {
+            return preview;
+        }
+
+        @Nullable
+        Size pictureSize() {
+            return picture;
+        }
+    }
+
+    /** Called when the camera has a new preview frame. */
+    private class CameraPreviewCallback implements Camera.PreviewCallback {
+        @Override
+        public void onPreviewFrame(byte[] data, Camera camera) {
+            processingRunnable.setNextFrame(data, camera);
+        }
+    }
+
+    /**
+     * This runnable controls access to the underlying receiver, calling it to process frames when
+     * available from the camera. This is designed to run detection on frames as fast as possible
+     * (i.e., without unnecessary context switching or waiting on the next frame).
+     *
+     * <p>While detection is running on a frame, new frames may be received from the camera. As these
+     * frames come in, the most recent frame is held onto as pending. As soon as detection and its
+     * associated processing is done for the previous frame, detection on the mostly recently received
+     * frame will immediately start on the same thread.
+     */
+    private class FrameProcessingRunnable implements Runnable {
+
+        // This lock guards all of the member variables below.
+        private final Object lock = new Object();
+        private boolean active = true;
+
+        // These pending variables hold the state associated with the new frame awaiting processing.
+        private ByteBuffer pendingFrameData;
+
+        FrameProcessingRunnable() {
+        }
+
+        /**
+         * Releases the underlying receiver. This is only safe to do after the associated thread has
+         * completed, which is managed in camera source's release method above.
+         */
+        @SuppressLint("Assert")
+        void release() {
+            assert (processingThread.getState() == State.TERMINATED);
+        }
+
+        /** Marks the runnable as active/not active. Signals any blocked threads to continue. */
+        void setActive(boolean active) {
+            synchronized (lock) {
+                this.active = active;
+                lock.notifyAll();
+            }
+        }
+
+        /**
+         * Sets the frame data received from the camera. This adds the previous unused frame buffer (if
+         * present) back to the camera, and keeps a pending reference to the frame data for future use.
+         */
+        void setNextFrame(byte[] data, Camera camera) {
+            synchronized (lock) {
+                if (pendingFrameData != null) {
+                    camera.addCallbackBuffer(pendingFrameData.array());
+                    pendingFrameData = null;
+                }
+
+                if (!bytesToByteBuffer.containsKey(data)) {
+                    Log.d(TAG, "Skipping frame. Could not find ByteBuffer associated with the image "
+                        + "data from the camera.");
+                    return;
+                }
+
+                pendingFrameData = bytesToByteBuffer.get(data);
+
+                // Notify the processor thread if it is waiting on the next frame (see below).
+                lock.notifyAll();
+            }
+        }
+
+        /**
+         * As long as the processing thread is active, this executes detection on frames continuously.
+         * The next pending frame is either immediately available or hasn't been received yet. Once it
+         * is available, we transfer the frame info to local variables and run detection on that frame.
+         * It immediately loops back for the next frame without pausing.
+         *
+         * <p>If detection takes longer than the time in between new frames from the camera, this will
+         * mean that this loop will run without ever waiting on a frame, avoiding any context switching
+         * or frame acquisition time latency.
+         *
+         * <p>If you find that this is using more CPU than you'd like, you should probably decrease the
+         * FPS setting above to allow for some idle time in between frames.
+         */
+        @SuppressLint("InlinedApi")
+        @SuppressWarnings("GuardedBy")
+        @Override
+        public void run() {
+            ByteBuffer data;
+
+            while (true) {
+                synchronized (lock) {
+                    while (active && (pendingFrameData == null)) {
+                        try {
+                            // Wait for the next frame to be received from the camera, since we
+                            // don't have it yet.
+                            lock.wait();
+                        } catch (InterruptedException e) {
+                            Log.d(TAG, "Frame processing loop terminated.", e);
+                            return;
+                        }
+                    }
+
+                    if (!active) {
+                        // Exit the loop once this camera source is stopped or released.  We check
+                        // this here, immediately after the wait() above, to handle the case where
+                        // setActive(false) had been called, triggering the termination of this
+                        // loop.
+                        return;
+                    }
+
+                    // Hold onto the frame data locally, so that we can use this for detection
+                    // below.  We need to clear pendingFrameData to ensure that this buffer isn't
+                    // recycled back to the camera before we are done using that data.
+                    data = pendingFrameData;
+                    pendingFrameData = null;
+                }
+
+                // The code below needs to run outside of synchronization, because this will allow
+                // the camera to add pending frame(s) while we are running detection on the current
+                // frame.
+
+                try {
+                    synchronized (processorLock) {
+                        Log.d(TAG, "Process an image");
+                        frameProcessor.process(data, new FrameMetadata.Builder().setWidth(previewSize.getWidth())
+                                                                                .setHeight(previewSize.getHeight())
+                                                                                .setRotation(rotation)
+                                                                                .setCameraFacing(facing).build(),
+                            graphicOverlay);
+                    }
+                } catch (Throwable t) {
+                    Log.e(TAG, "Exception thrown from receiver.", t);
+                } finally {
+                    camera.addCallbackBuffer(data.array());
+                }
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/common/CameraSourcePreview.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/common/CameraSourcePreview.java
@@ -1,0 +1,181 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode.common;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+import android.view.ViewGroup;
+
+import com.google.android.gms.common.images.Size;
+
+import java.io.IOException;
+
+/** Preview the camera image in the screen. */
+public class CameraSourcePreview extends ViewGroup {
+    private static final String TAG = "MIDemoApp:Preview";
+
+    private Context context;
+    private SurfaceView surfaceView;
+    private boolean startRequested;
+    private boolean surfaceAvailable;
+    private CameraSource cameraSource;
+
+    private GraphicOverlay overlay;
+
+    public CameraSourcePreview(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        this.context = context;
+        startRequested = false;
+        surfaceAvailable = false;
+
+        surfaceView = new SurfaceView(context);
+        surfaceView.getHolder().addCallback(new SurfaceCallback());
+        addView(surfaceView);
+    }
+
+    public void start(CameraSource cameraSource) throws IOException {
+        if (cameraSource == null) {
+            stop();
+        }
+
+        this.cameraSource = cameraSource;
+
+        if (this.cameraSource != null) {
+            startRequested = true;
+            startIfReady();
+        }
+    }
+
+    public void start(CameraSource cameraSource, GraphicOverlay overlay) throws IOException {
+        this.overlay = overlay;
+        start(cameraSource);
+    }
+
+    public void stop() {
+        if (cameraSource != null) {
+            cameraSource.stop();
+        }
+    }
+
+    public void release() {
+        if (cameraSource != null) {
+            cameraSource.release();
+            cameraSource = null;
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private void startIfReady() throws IOException {
+        if (startRequested && surfaceAvailable) {
+            cameraSource.start();
+            if (overlay != null) {
+                Size size = cameraSource.getPreviewSize();
+                int min = Math.min(size.getWidth(), size.getHeight());
+                int max = Math.max(size.getWidth(), size.getHeight());
+                if (isPortraitMode()) {
+                    // Swap width and height sizes when in portrait, since it will be rotated by
+                    // 90 degrees
+                    overlay.setCameraInfo(min, max, cameraSource.getCameraFacing());
+                } else {
+                    overlay.setCameraInfo(max, min, cameraSource.getCameraFacing());
+                }
+                overlay.clear();
+            }
+            startRequested = false;
+        }
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        int width = 320;
+        int height = 240;
+        if (cameraSource != null) {
+            Size size = cameraSource.getPreviewSize();
+            if (size != null) {
+                width = size.getWidth();
+                height = size.getHeight();
+            }
+        }
+
+        // Swap width and height sizes when in portrait, since it will be rotated 90 degrees
+        if (isPortraitMode()) {
+            int tmp = width;
+            width = height;
+            height = tmp;
+        }
+
+        final int layoutWidth = right - left;
+        final int layoutHeight = bottom - top;
+
+        // Computes height and width for potentially doing fit width.
+        int childWidth = layoutWidth;
+        int childHeight = (int) (((float) layoutWidth / (float) width) * height);
+
+        // If height is too tall using fit width, does fit height instead.
+        if (childHeight > layoutHeight) {
+            childHeight = layoutHeight;
+            childWidth = (int) (((float) layoutHeight / (float) height) * width);
+        }
+
+        for (int i = 0; i < getChildCount(); ++i) {
+            getChildAt(i).layout(0, 0, childWidth, childHeight);
+            Log.d(TAG, "Assigned view: " + i);
+        }
+
+        try {
+            startIfReady();
+        } catch (IOException e) {
+            Log.e(TAG, "Could not start camera source.", e);
+        }
+    }
+
+    private boolean isPortraitMode() {
+        int orientation = context.getResources().getConfiguration().orientation;
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            return false;
+        }
+        if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+            return true;
+        }
+
+        Log.d(TAG, "isPortraitMode returning false by default");
+        return false;
+    }
+
+    private class SurfaceCallback implements SurfaceHolder.Callback {
+        @Override
+        public void surfaceCreated(SurfaceHolder surface) {
+            surfaceAvailable = true;
+            try {
+                startIfReady();
+            } catch (IOException e) {
+                Log.e(TAG, "Could not start camera source.", e);
+            }
+        }
+
+        @Override
+        public void surfaceDestroyed(SurfaceHolder surface) {
+            surfaceAvailable = false;
+        }
+
+        @Override
+        public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+        }
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/common/FrameMetadata.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/common/FrameMetadata.java
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode.common;
+
+/** Describing a frame info. */
+public class FrameMetadata {
+
+    private final int width;
+    private final int height;
+    private final int rotation;
+    private final int cameraFacing;
+
+    private FrameMetadata(int width, int height, int rotation, int facing) {
+        this.width = width;
+        this.height = height;
+        this.rotation = rotation;
+        cameraFacing = facing;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public int getRotation() {
+        return rotation;
+    }
+
+    public int getCameraFacing() {
+        return cameraFacing;
+    }
+
+    /** Builder of {@link FrameMetadata}. */
+    public static class Builder {
+
+        private int width;
+        private int height;
+        private int rotation;
+        private int cameraFacing;
+
+        public Builder setWidth(int width) {
+            this.width = width;
+            return this;
+        }
+
+        public Builder setHeight(int height) {
+            this.height = height;
+            return this;
+        }
+
+        public Builder setRotation(int rotation) {
+            this.rotation = rotation;
+            return this;
+        }
+
+        public Builder setCameraFacing(int facing) {
+            cameraFacing = facing;
+            return this;
+        }
+
+        public FrameMetadata build() {
+            return new FrameMetadata(width, height, rotation, cameraFacing);
+        }
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/common/GraphicOverlay.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/common/GraphicOverlay.java
@@ -1,0 +1,199 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode.common;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.google.android.gms.vision.CameraSource;
+import com.vijay.jsonwizard.barcode.barcodescanning.BarcodeGraphic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A view which renders a series of custom graphics to be overlayed on top of an associated preview
+ * (i.e., the camera preview). The creator can add graphics objects, update the objects, and remove
+ * them, triggering the appropriate drawing and invalidation within the view.
+ *
+ * <p>Supports scaling and mirroring of the graphics relative the camera's preview properties. The
+ * idea is that detection items are expressed in terms of a preview size, but need to be scaled up
+ * to the full view size, and also mirrored in the case of the front-facing camera.
+ *
+ * <p>Associated {@link Graphic} items should use the following methods to convert to view
+ * coordinates for the graphics that are drawn:
+ *
+ * <ol>
+ * <li>{@link Graphic#scaleX(float)} and {@link Graphic#scaleY(float)} adjust the size of the
+ * supplied value from the preview scale to the view scale.
+ * <li>{@link Graphic#translateX(float)} and {@link Graphic#translateY(float)} adjust the
+ * coordinate from the preview's coordinate system to the view coordinate system.
+ * </ol>
+ */
+public class GraphicOverlay extends View {
+    private final Object lock = new Object();
+    private final List<Graphic> graphics = new ArrayList<>();
+    private int previewWidth;
+    private float widthScaleFactor = 1.0f;
+    private int previewHeight;
+    private float heightScaleFactor = 1.0f;
+    private int facing = CameraSource.CAMERA_FACING_BACK;
+
+    public GraphicOverlay(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+    }
+
+    /** Removes all graphics from the overlay. */
+    public void clear() {
+        synchronized (lock) {
+            graphics.clear();
+        }
+        postInvalidate();
+    }
+
+    /** Adds a graphic to the overlay. */
+    public void add(Graphic graphic) {
+        synchronized (lock) {
+            graphics.add(graphic);
+        }
+    }
+
+    /** Removes a graphic from the overlay. */
+    public void remove(Graphic graphic) {
+        synchronized (lock) {
+            graphics.remove(graphic);
+        }
+        postInvalidate();
+    }
+
+    /**
+     * Sets the camera attributes for size and facing direction, which informs how to transform image
+     * coordinates later.
+     */
+    public void setCameraInfo(int previewWidth, int previewHeight, int facing) {
+        synchronized (lock) {
+            this.previewWidth = previewWidth;
+            this.previewHeight = previewHeight;
+            this.facing = facing;
+        }
+        postInvalidate();
+    }
+
+    /** Draws the overlay with its associated graphic objects. */
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        synchronized (lock) {
+            if ((previewWidth != 0) && (previewHeight != 0)) {
+                widthScaleFactor = (float) canvas.getWidth() / (float) previewWidth;
+                heightScaleFactor = (float) canvas.getHeight() / (float) previewHeight;
+            }
+
+            for (Graphic graphic: graphics) {
+                graphic.draw(canvas);
+            }
+        }
+    }
+
+    public List<Graphic> getGraphics() {
+        return this.graphics;
+    }
+
+    public void highlight(BarcodeGraphic graphic) {
+        for (Graphic graph: graphics) {
+            if (graph instanceof BarcodeGraphic) {
+                BarcodeGraphic bcgraph = (BarcodeGraphic) graph;
+                if (bcgraph == graphic) {
+                    bcgraph.highlight();
+                } else {
+                    bcgraph.removeHighlight();
+                }
+            }
+        }
+    }
+
+    /**
+     * Base class for a custom graphics object to be rendered within the graphic overlay. Subclass
+     * this and implement the {@link Graphic#draw(Canvas)} method to define the graphics element. Add
+     * instances to the overlay using {@link GraphicOverlay#add(Graphic)}.
+     */
+    public abstract static class Graphic {
+        private GraphicOverlay overlay;
+
+        public Graphic(GraphicOverlay overlay) {
+            this.overlay = overlay;
+        }
+
+        /**
+         * Draw the graphic on the supplied canvas. Drawing should use the following methods to convert
+         * to view coordinates for the graphics that are drawn:
+         *
+         * <ol>
+         * <li>{@link Graphic#scaleX(float)} and {@link Graphic#scaleY(float)} adjust the size of the
+         * supplied value from the preview scale to the view scale.
+         * <li>{@link Graphic#translateX(float)} and {@link Graphic#translateY(float)} adjust the
+         * coordinate from the preview's coordinate system to the view coordinate system.
+         * </ol>
+         *
+         * @param canvas drawing canvas
+         */
+        public abstract void draw(Canvas canvas);
+
+        /**
+         * Adjusts a horizontal value of the supplied value from the preview scale to the view scale.
+         */
+        public float scaleX(float horizontal) {
+            return horizontal * overlay.widthScaleFactor;
+        }
+
+        /** Adjusts a vertical value of the supplied value from the preview scale to the view scale. */
+        public float scaleY(float vertical) {
+            return vertical * overlay.heightScaleFactor;
+        }
+
+        /** Returns the application context of the app. */
+        public Context getApplicationContext() {
+            return overlay.getContext().getApplicationContext();
+        }
+
+        /**
+         * Adjusts the x coordinate from the preview's coordinate system to the view coordinate system.
+         */
+        public float translateX(float x) {
+            if (overlay.facing == CameraSource.CAMERA_FACING_FRONT) {
+                return overlay.getWidth() - scaleX(x);
+            } else {
+                return scaleX(x);
+            }
+        }
+
+        /**
+         * Adjusts the y coordinate from the preview's coordinate system to the view coordinate system.
+         */
+        public float translateY(float y) {
+            return scaleY(y);
+        }
+
+        public void postInvalidate() {
+            overlay.postInvalidate();
+        }
+
+
+    }
+
+}

--- a/library/src/main/java/com/vijay/jsonwizard/barcode/common/VisionImageProcessor.java
+++ b/library/src/main/java/com/vijay/jsonwizard/barcode/common/VisionImageProcessor.java
@@ -1,0 +1,36 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.vijay.jsonwizard.barcode.common;
+
+import android.graphics.Bitmap;
+
+import com.google.firebase.ml.common.FirebaseMLException;
+
+import java.nio.ByteBuffer;
+
+/** An inferface to process the images with different ML Kit detectors and custom image models. */
+public interface VisionImageProcessor {
+
+    /** Processes the images with the underlying machine learning models. */
+    void process(ByteBuffer data, FrameMetadata frameMetadata, GraphicOverlay graphicOverlay)
+        throws FirebaseMLException;
+
+    /** Processes the bitmap images. */
+    void process(Bitmap bitmap, GraphicOverlay graphicOverlay);
+
+    /** Stops the underlying machine learning model and release resources. */
+    void stop();
+
+    void pause();
+}

--- a/library/src/main/java/com/vijay/jsonwizard/constants/JsonFormConstants.java
+++ b/library/src/main/java/com/vijay/jsonwizard/constants/JsonFormConstants.java
@@ -6,6 +6,7 @@ package com.vijay.jsonwizard.constants;
 public class JsonFormConstants {
 
     public static final String FIRST_STEP_NAME = "step1";
+    public static final String BARCODE_TEXT = "barcode_text";
     public static final String EDIT_TEXT = "edit_text";
     public static final String CHECK_BOX = "check_box";
     public static final String RADIO_BUTTON = "radio";

--- a/library/src/main/java/com/vijay/jsonwizard/customviews/CheckBox.java
+++ b/library/src/main/java/com/vijay/jsonwizard/customviews/CheckBox.java
@@ -51,9 +51,8 @@ public class CheckBox extends CompoundButton {
     /**
      * Change the checked state of this button immediately without showing
      * animation.
-     * 
-     * @param checked
-     *            The checked state.
+     *
+     * @param checked The checked state.
      */
     public void setCheckedImmediately(boolean checked) {
         if (mButtonDrawable instanceof CheckBoxDrawable) {

--- a/library/src/main/java/com/vijay/jsonwizard/customviews/CompoundButton.java
+++ b/library/src/main/java/com/vijay/jsonwizard/customviews/CompoundButton.java
@@ -5,17 +5,18 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+
+import androidx.annotation.NonNull;
 
 import com.rey.material.drawable.RippleDrawable;
 import com.rey.material.widget.RippleManager;
 
 public class CompoundButton extends android.widget.CompoundButton {
 
+    protected Drawable mButtonDrawable;
     private RippleManager mRippleManager = new RippleManager();
-    protected Drawable    mButtonDrawable;
 
     public CompoundButton(Context context) {
         super(context);
@@ -45,8 +46,8 @@ public class CompoundButton extends android.widget.CompoundButton {
     private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         // a fix to reset paddingLeft attribute
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            TypedArray a = context.obtainStyledAttributes(attrs, new int[] { android.R.attr.padding,
-                    android.R.attr.paddingLeft }, defStyleAttr, defStyleRes);
+            TypedArray a = context.obtainStyledAttributes(attrs,
+                new int[]{android.R.attr.padding, android.R.attr.paddingLeft}, defStyleAttr, defStyleRes);
 
             if (!a.hasValue(0) && !a.hasValue(1)) {
                 setPadding(0, getPaddingTop(), getPaddingRight(), getPaddingBottom());

--- a/library/src/main/java/com/vijay/jsonwizard/customviews/GenericTextWatcher.java
+++ b/library/src/main/java/com/vijay/jsonwizard/customviews/GenericTextWatcher.java
@@ -16,7 +16,7 @@ public class GenericTextWatcher implements TextWatcher {
 
     private static final String TAG = "GenericTextWatcher";
 
-    private View   mView;
+    private View mView;
     private String mStepName;
 
     public GenericTextWatcher(String stepName, View view) {
@@ -36,9 +36,9 @@ public class GenericTextWatcher implements TextWatcher {
         String text = editable.toString();
         JsonApi api = null;
         Context ctx = mView.getContext();
-        if(ctx instanceof JsonApi) {
+        if (ctx instanceof JsonApi) {
             api = (JsonApi) ctx;
-        } else if(ctx instanceof ContextWrapper) {
+        } else if (ctx instanceof ContextWrapper) {
             ContextWrapper contextWrapper = (ContextWrapper) ctx;
             api = (JsonApi) contextWrapper.getBaseContext();
         } else {

--- a/library/src/main/java/com/vijay/jsonwizard/customviews/RadioButton.java
+++ b/library/src/main/java/com/vijay/jsonwizard/customviews/RadioButton.java
@@ -43,7 +43,7 @@ public class RadioButton extends CompoundButton {
 
     private void internalApplyStyle(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         RadioButtonDrawable drawable = new RadioButtonDrawable.Builder(context, attrs, defStyleAttr, defStyleRes)
-                .build();
+            .build();
         drawable.setInEditMode(isInEditMode());
         drawable.setAnimEnable(false);
         setButtonDrawable(null);
@@ -63,9 +63,8 @@ public class RadioButton extends CompoundButton {
     /**
      * Change the checked state of this button immediately without showing
      * animation.
-     * 
-     * @param checked
-     *            The checked state.
+     *
+     * @param checked The checked state.
      */
     public void setCheckedImmediately(boolean checked) {
         if (mButtonDrawable instanceof RadioButtonDrawable) {

--- a/library/src/main/java/com/vijay/jsonwizard/demo/resources/AssetsResourceResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/demo/resources/AssetsResourceResolver.java
@@ -8,26 +8,15 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 
-public class AssetsResourceResolver implements ResourceResolver{
+public class AssetsResourceResolver implements ResourceResolver {
 
     private static final String TAG = "AssetsResourceResolver";
 
-    @Override
-    public String resolvePath(Context context, String id) {
-        String imagePath = id;
-        if (!TextUtils.isEmpty(imagePath)) {
-            imagePath = moveAssetToCache(context, imagePath, "imagenes");
-        }
-        return imagePath;
-    }
-
-    private static String moveAssetToCache(Context context, String assetName,
-                                           String assetFolderName) {
+    private static String moveAssetToCache(Context context, String assetName, String assetFolderName) {
 
         File f = new File(context.getCacheDir() + File.separator + assetName);
         if (!f.exists()) {
-            try (InputStream is = context.getAssets()
-                    .open(assetFolderName + File.separator + assetName);
+            try (InputStream is = context.getAssets().open(assetFolderName + File.separator + assetName);
                  FileOutputStream fos = new FileOutputStream(f);) {
 
                 byte[] buffer = new byte[1024];
@@ -39,11 +28,19 @@ public class AssetsResourceResolver implements ResourceResolver{
                 fos.flush();
 
             } catch (Exception e) {
-                Log.e(TAG, "moveAssetToCache: Error moving asset " + assetFolderName + " to cache",
-                        e);
+                Log.e(TAG, "moveAssetToCache: Error moving asset " + assetFolderName + " to cache", e);
                 return null;
             }
         }
         return f.getAbsolutePath();
+    }
+
+    @Override
+    public String resolvePath(Context context, String id) {
+        String imagePath = id;
+        if (!TextUtils.isEmpty(imagePath)) {
+            imagePath = moveAssetToCache(context, imagePath, "imagenes");
+        }
+        return imagePath;
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/demo/resources/ResourceResolverFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/demo/resources/ResourceResolverFactory.java
@@ -3,8 +3,6 @@ package com.vijay.jsonwizard.demo.resources;
 import android.content.Context;
 import android.util.Log;
 
-import com.vijay.jsonwizard.expressions.ExternalContentResolver;
-
 public class ResourceResolverFactory {
 
     private static final String TAG = "ExtContentResolverFact";
@@ -19,7 +17,7 @@ public class ResourceResolverFactory {
             }
             return (ResourceResolver) instance;
         } catch (Exception e) {
-            Log.e(TAG, "Error creating ResourceResolver instance",e);
+            Log.e(TAG, "Error creating ResourceResolver instance", e);
         }
         return null;
     }

--- a/library/src/main/java/com/vijay/jsonwizard/expressions/ExternalContentLru.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/ExternalContentLru.java
@@ -1,10 +1,13 @@
 package com.vijay.jsonwizard.expressions;
 
 
-import android.support.v4.util.LruCache;
 import android.util.Log;
+
+import androidx.collection.LruCache;
+
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+
 import org.json.JSONObject;
 
 public class ExternalContentLru extends LruCache<String, DocumentContext> {
@@ -14,8 +17,8 @@ public class ExternalContentLru extends LruCache<String, DocumentContext> {
 
     /**
      * @param maxSize for caches that do not override {@link #sizeOf}, this is
-     * the maximum number of entries in the cache. For all other caches,
-     * this is the maximum sum of the sizes of the entries in this cache.
+     *     the maximum number of entries in the cache. For all other caches,
+     *     this is the maximum sum of the sizes of the entries in this cache.
      */
     public ExternalContentLru(ExternalContentResolver contentResolver, int maxSize) {
         super(maxSize);

--- a/library/src/main/java/com/vijay/jsonwizard/expressions/ExternalContentResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/ExternalContentResolver.java
@@ -1,9 +1,11 @@
 package com.vijay.jsonwizard.expressions;
 
 import android.content.Context;
+
 import org.json.JSONObject;
 
 public interface ExternalContentResolver {
     public void setContext(Context context);
+
     public JSONObject loadExtenalContent(String id);
 }

--- a/library/src/main/java/com/vijay/jsonwizard/expressions/ExternalContentResolverFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/ExternalContentResolverFactory.java
@@ -15,10 +15,10 @@ public class ExternalContentResolverFactory {
                 Log.e(TAG, "Instance should be an instance of ExternalContentResolver");
                 throw new InstantiationException();
             }
-            ((ExternalContentResolver)instance).setContext(context);
+            ((ExternalContentResolver) instance).setContext(context);
             return (ExternalContentResolver) instance;
         } catch (Exception e) {
-            Log.e(TAG, "Error creating ExternalContentResolver instance",e);
+            Log.e(TAG, "Error creating ExternalContentResolver instance", e);
         }
         return null;
     }

--- a/library/src/main/java/com/vijay/jsonwizard/fragments/JsonFormFragment.java
+++ b/library/src/main/java/com/vijay/jsonwizard/fragments/JsonFormFragment.java
@@ -1,11 +1,30 @@
 package com.vijay.jsonwizard.fragments;
 
-import java.util.List;
-import java.util.Locale;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.CompoundButton;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RadioGroup;
+import android.widget.Toast;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
 
+import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rey.material.widget.Switch;
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.activities.JsonFormActivity;
@@ -21,45 +40,36 @@ import com.vijay.jsonwizard.utils.CarouselAdapter;
 import com.vijay.jsonwizard.views.JsonFormFragmentView;
 import com.vijay.jsonwizard.viewstates.JsonFormFragmentViewState;
 
-import android.app.Activity;
-import android.content.Context;
-import android.content.Intent;
-import android.graphics.Bitmap;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.app.ActionBar;
-import android.support.v7.widget.Toolbar;
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.CompoundButton;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.RadioGroup;
-import android.widget.Toast;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Created by vijay on 5/7/15.
  */
-public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, JsonFormFragmentViewState> implements
-        CommonListener, JsonFormFragmentView<JsonFormFragmentViewState> {
+public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, JsonFormFragmentViewState>
+    implements CommonListener, JsonFormFragmentView<JsonFormFragmentViewState> {
     private static final String TAG = "JsonFormFragment";
-    private LinearLayout        mMainView;
-    private Menu                mMenu;
-    private JsonApi             mJsonApi;
+    private LinearLayout mMainView;
+    private Menu mMenu;
+    private JsonApi mJsonApi;
 
-    public void setJsonApi(JsonApi jsonApi) {
-        this.mJsonApi = jsonApi;
+    public static JsonFormFragment getFormFragment(String stepName) {
+        JsonFormFragment jsonFormFragment = new JsonFormFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString("stepName", stepName);
+        jsonFormFragment.setArguments(bundle);
+        return jsonFormFragment;
     }
 
     public JsonApi getJsonApi() {
         return mJsonApi;
+    }
+
+    public void setJsonApi(JsonApi jsonApi) {
+        this.mJsonApi = jsonApi;
     }
 
     @Override
@@ -77,7 +87,8 @@ public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, Jso
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+        @Nullable Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_json_wizard, null);
         mMainView = (LinearLayout) rootView.findViewById(R.id.main_layout);
         return rootView;
@@ -159,6 +170,38 @@ public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, Jso
         }
     }
 
+    private MaterialEditText findMaterialiEditTextByTag(ViewGroup v, String searchKey) {
+
+        MaterialEditText found = null;
+
+        for (int i = 0; i < v.getChildCount(); i++) {
+            Object child = v.getChildAt(i);
+            if (child instanceof MaterialEditText) {
+                MaterialEditText editText = (MaterialEditText) child;
+                String key = (String) editText.getTag(R.id.key);
+                if (key.equals(searchKey)) {
+                    return editText;
+                }
+            } else if (child instanceof ViewGroup) {
+                found = findMaterialiEditTextByTag((ViewGroup) child, searchKey);
+                if (found != null) {
+                    break;
+                }
+            }
+        }
+        return found;
+
+    }
+
+    @Override
+    public void updateRelevantEditText(String currentKey, String value) {
+
+        MaterialEditText editText = findMaterialiEditTextByTag(mMainView, currentKey);
+        if (editText != null) {
+            editText.setText(value);
+        }
+    }
+
     @Override
     public void writeValue(String stepName, String key, String s) {
         try {
@@ -204,7 +247,6 @@ public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, Jso
         Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
     }
 
-
     @Override
     public CommonListener getCommonListener() {
         return this;
@@ -212,7 +254,7 @@ public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, Jso
 
     @Override
     public void addFormElements(List<View> views) {
-        for (View view : views) {
+        for (View view: views) {
             mMainView.addView(view);
         }
     }
@@ -285,20 +327,9 @@ public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, Jso
 
     @Override
     public void transactThis(JsonFormFragment next) {
-        getActivity()
-                .getSupportFragmentManager()
-                .beginTransaction()
-                .setCustomAnimations(R.anim.enter_from_right, R.anim.exit_to_left, R.anim.enter_from_left,
-                        R.anim.exit_to_right).replace(R.id.container, next)
-                .addToBackStack(next.getClass().getSimpleName()).commit();
-    }
-
-    public static JsonFormFragment getFormFragment(String stepName) {
-        JsonFormFragment jsonFormFragment = new JsonFormFragment();
-        Bundle bundle = new Bundle();
-        bundle.putString("stepName", stepName);
-        jsonFormFragment.setArguments(bundle);
-        return jsonFormFragment;
+        getActivity().getSupportFragmentManager().beginTransaction().setCustomAnimations(R.anim.enter_from_right,
+            R.anim.exit_to_left, R.anim.enter_from_left, R.anim.exit_to_right).replace(R.id.container, next)
+                     .addToBackStack(next.getClass().getSimpleName()).commit();
     }
 
     @Override
@@ -371,8 +402,8 @@ public class JsonFormFragment extends MvpFragment<JsonFormFragmentPresenter, Jso
     }
 
     @Override
-    public void onScroll(float scrollPosition, int currentPosition, int newPosition, @Nullable CarouselAdapter
-            .ViewHolder currentHolder, @Nullable CarouselAdapter.ViewHolder newCurrent) {
+    public void onScroll(float scrollPosition, int currentPosition, int newPosition,
+        @Nullable CarouselAdapter.ViewHolder currentHolder, @Nullable CarouselAdapter.ViewHolder newCurrent) {
 
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/i18n/JsonFormBundle.java
+++ b/library/src/main/java/com/vijay/jsonwizard/i18n/JsonFormBundle.java
@@ -27,15 +27,15 @@ public class JsonFormBundle {
 
     public JsonFormBundle(JSONObject form, Locale locale) throws JSONException {
         mBundle = new HashMap<>();
-        if(form.has("bundle")){
+        if (form.has("bundle")) {
             loadBundle(form.getJSONObject("bundle"), locale.getLanguage());
         }
     }
 
     public String resolveKey(String key) {
-        if(!TextUtils.isEmpty(key) && key.startsWith(BUNDLE_KEY_PREFIX) && key.endsWith(BUNDLE_KEY_SUFIX)){
+        if (!TextUtils.isEmpty(key) && key.startsWith(BUNDLE_KEY_PREFIX) && key.endsWith(BUNDLE_KEY_SUFIX)) {
             final String finalKey = key.substring(2, key.length() - 1);
-            if(mBundle.containsKey(finalKey)) {
+            if (mBundle.containsKey(finalKey)) {
                 return mBundle.get(finalKey);
             }
         }
@@ -44,13 +44,13 @@ public class JsonFormBundle {
 
     private void loadBundle(JSONObject bundle, String country) throws JSONException {
         String lang = country;
-        if(!bundle.has(lang)){
+        if (!bundle.has(lang)) {
             lang = getDefaultLang(bundle);
         }
-        if(!"".equals(lang)){
+        if (!"".equals(lang)) {
             JSONObject translations = bundle.getJSONObject(lang);
             Iterator<String> transIter = translations.keys();
-            while(transIter.hasNext()){
+            while (transIter.hasNext()) {
                 String key = transIter.next();
                 mBundle.put(key, translations.getString(key));
             }
@@ -59,14 +59,14 @@ public class JsonFormBundle {
 
     private String getDefaultLang(JSONObject bundle) {
         String defLang = "";
-        for(int i = 0; i< bundle.names().length(); i++){
+        for (int i = 0; i < bundle.names().length(); i++) {
             try {
                 String currentLang = bundle.names().getString(i);
-                if("".equals(defLang)){
+                if ("".equals(defLang)) {
                     defLang = currentLang;
                 }
                 JSONObject translations = bundle.getJSONObject(currentLang);
-                if(translations.optBoolean(BUNDLE_DEFAULT_PROPERTY)) {
+                if (translations.optBoolean(BUNDLE_DEFAULT_PROPERTY)) {
                     return currentLang;
                 }
             } catch (JSONException e) {

--- a/library/src/main/java/com/vijay/jsonwizard/interactors/JsonFormInteractor.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interactors/JsonFormInteractor.java
@@ -1,27 +1,18 @@
 package com.vijay.jsonwizard.interactors;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 
-import com.vijay.jsonwizard.constants.JsonFormConstants;
+import androidx.annotation.Nullable;
+
 import com.vijay.jsonwizard.demo.resources.ResourceResolver;
 import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
-import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
-import com.vijay.jsonwizard.widgets.CheckBoxFactory;
-import com.vijay.jsonwizard.widgets.DatePickerFactory;
-import com.vijay.jsonwizard.widgets.EditGroupFactory;
-import com.vijay.jsonwizard.widgets.EditTextFactory;
-import com.vijay.jsonwizard.widgets.ImagePickerFactory;
-import com.vijay.jsonwizard.widgets.LabelFactory;
-import com.vijay.jsonwizard.widgets.RadioButtonFactory;
-import com.vijay.jsonwizard.widgets.SpinnerFactory;
 import com.vijay.jsonwizard.widgets.WidgetFactoryRegistry;
 
 import org.json.JSONArray;
@@ -29,10 +20,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 /**
  * Created by vijay on 5/19/15.
@@ -45,9 +33,13 @@ public class JsonFormInteractor {
     private JsonFormInteractor() {
     }
 
+    public static JsonFormInteractor getInstance() {
+        return INSTANCE;
+    }
+
     public List<View> fetchFormElements(String stepName, Context context, JSONObject parentJson,
-                                        CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
-                                        ResourceResolver resourceResolver, int visualizationMode) {
+        CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
+        ResourceResolver resourceResolver, int visualizationMode) {
         Log.d(TAG, "fetchFormElements called");
         List<View> viewsFromJson = new ArrayList<>(5);
         try {
@@ -56,18 +48,15 @@ public class JsonFormInteractor {
                 JSONObject childJson = fields.getJSONObject(i);
                 if (isVisible(childJson, context, resolver)) {
                     try {
-                        List<View> views = WidgetFactoryRegistry
-                                .getWidgetFactory(childJson.getString("type")).
-                                        getViewsFromJson(stepName, context, childJson, listener,
-                                                bundle, resolver, resourceResolver, visualizationMode);
+                        List<View> views = WidgetFactoryRegistry.getWidgetFactory(childJson.getString("type")).
+                            getViewsFromJson(stepName, context, childJson, listener, bundle, resolver, resourceResolver,
+                                visualizationMode);
                         if (views.size() > 0) {
                             viewsFromJson.addAll(views);
                         }
                     } catch (Exception e) {
-                        Log.e(TAG,
-                                "Exception occurred in making child view at index : " + i
-                                        + " : Exception is : "
-                                        + e.getMessage(), e);
+                        Log.e(TAG, "Exception occurred in making child view at index : " + i + " : Exception is : " + e
+                            .getMessage(), e);
                     }
                 }
             }
@@ -77,8 +66,7 @@ public class JsonFormInteractor {
         return viewsFromJson;
     }
 
-    private boolean isVisible(JSONObject jsonObject, Context context,
-            JsonExpressionResolver resolver) {
+    private boolean isVisible(JSONObject jsonObject, Context context, JsonExpressionResolver resolver) {
 
         final String showExpression = jsonObject.optString("show");
         if (!TextUtils.isEmpty(showExpression)) {
@@ -122,9 +110,5 @@ public class JsonFormInteractor {
             currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
         }
         return currentValues;
-    }
-
-    public static JsonFormInteractor getInstance() {
-        return INSTANCE;
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/interfaces/CommonListener.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interfaces/CommonListener.java
@@ -1,21 +1,19 @@
 package com.vijay.jsonwizard.interfaces;
 
-import com.rey.material.widget.Switch;
-import com.vijay.jsonwizard.utils.CarouselAdapter;
-import com.yarolegovich.discretescrollview.DiscreteScrollView;
-
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.Spinner;
 
+import com.rey.material.widget.Switch;
+import com.vijay.jsonwizard.utils.CarouselAdapter;
+import com.yarolegovich.discretescrollview.DiscreteScrollView;
+
 /**
  * Created by vijay on 5/17/15.
  */
-public interface CommonListener extends View.OnClickListener,
-        CompoundButton.OnCheckedChangeListener,
-        Spinner.OnItemSelectedListener,
-        Switch.OnCheckedChangeListener,
-        OnFieldStateChangeListener,
-        DiscreteScrollView.ScrollStateChangeListener<CarouselAdapter.ViewHolder>,
-        DiscreteScrollView.OnItemChangedListener<CarouselAdapter.ViewHolder> {
+public interface CommonListener
+    extends View.OnClickListener, CompoundButton.OnCheckedChangeListener, Spinner.OnItemSelectedListener,
+    Switch.OnCheckedChangeListener, OnFieldStateChangeListener,
+    DiscreteScrollView.ScrollStateChangeListener<CarouselAdapter.ViewHolder>,
+    DiscreteScrollView.OnItemChangedListener<CarouselAdapter.ViewHolder> {
 }

--- a/library/src/main/java/com/vijay/jsonwizard/interfaces/FormWidgetFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interfaces/FormWidgetFactory.java
@@ -10,15 +10,14 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import org.json.JSONObject;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by vijay on 24-05-2015.
  */
 public interface FormWidgetFactory {
 
-    List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject,
-                                CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
-                                ResourceResolver resourceResolver, int visualizationMode) throws Exception;
+    List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws Exception;
 
 }

--- a/library/src/main/java/com/vijay/jsonwizard/interfaces/JsonApi.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interfaces/JsonApi.java
@@ -19,7 +19,7 @@ public interface JsonApi {
     void writeValue(String stepName, String key, String value) throws JSONException;
 
     void writeValue(String stepName, String prentKey, String childObjectKey, String childKey, String value)
-            throws JSONException;
+        throws JSONException;
 
     String currentJsonState();
 

--- a/library/src/main/java/com/vijay/jsonwizard/interfaces/OnFieldStateChangeListener.java
+++ b/library/src/main/java/com/vijay/jsonwizard/interfaces/OnFieldStateChangeListener.java
@@ -7,7 +7,9 @@ package com.vijay.jsonwizard.interfaces;
 public interface OnFieldStateChangeListener {
 
     void onInitialValueSet(String parentKey, String childKey, String value);
+
     void onValueChange(String parentKey, String childKey, String value);
+
     void onVisibilityChange(String key, String o, boolean b);
 
 }

--- a/library/src/main/java/com/vijay/jsonwizard/mvp/BaseActivity.java
+++ b/library/src/main/java/com/vijay/jsonwizard/mvp/BaseActivity.java
@@ -1,9 +1,10 @@
 package com.vijay.jsonwizard.mvp;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Created by vijay on 4/21/15.

--- a/library/src/main/java/com/vijay/jsonwizard/mvp/BaseFragment.java
+++ b/library/src/main/java/com/vijay/jsonwizard/mvp/BaseFragment.java
@@ -1,11 +1,12 @@
 package com.vijay.jsonwizard.mvp;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
 /**
  * Created by vijay on 4/19/15.
@@ -38,8 +39,8 @@ public abstract class BaseFragment<VS extends ViewState> extends Fragment {
         int layoutRes = getLayoutRes();
         if (layoutRes == 0) {
             throw new IllegalArgumentException("getLayoutRes() returned 0, which is not allowed. "
-                    + "If you don't want to use getLayoutRes() but implement your own view for this "
-                    + "fragment manually, then you have to override onCreateView();");
+                + "If you don't want to use getLayoutRes() but implement your own view for this "
+                + "fragment manually, then you have to override onCreateView();");
         } else {
             View v = inflater.inflate(layoutRes, container, false);
             return v;

--- a/library/src/main/java/com/vijay/jsonwizard/mvp/MvpActivity.java
+++ b/library/src/main/java/com/vijay/jsonwizard/mvp/MvpActivity.java
@@ -2,8 +2,8 @@ package com.vijay.jsonwizard.mvp;
 
 import android.os.Bundle;
 
-public abstract class MvpActivity<P extends MvpPresenter, VS extends ViewState> extends BaseActivity<VS> implements
-        MvpView {
+public abstract class MvpActivity<P extends MvpPresenter, VS extends ViewState> extends BaseActivity<VS>
+    implements MvpView {
 
     protected P presenter;
 

--- a/library/src/main/java/com/vijay/jsonwizard/mvp/MvpBasePresenter.java
+++ b/library/src/main/java/com/vijay/jsonwizard/mvp/MvpBasePresenter.java
@@ -16,7 +16,7 @@ public class MvpBasePresenter<V extends MvpView> implements MvpPresenter<V> {
      * to check if the view is attached to avoid NullPointerExceptions
      */
     protected V getView() {
-        if(viewRef!=null) {
+        if (viewRef != null) {
             return viewRef.get();
         }
         return null;

--- a/library/src/main/java/com/vijay/jsonwizard/mvp/MvpFragment.java
+++ b/library/src/main/java/com/vijay/jsonwizard/mvp/MvpFragment.java
@@ -2,12 +2,13 @@ package com.vijay.jsonwizard.mvp;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
-public abstract class MvpFragment<P extends MvpPresenter, VS extends ViewState> extends BaseFragment<VS> implements
-        MvpView {
+import androidx.annotation.Nullable;
+
+public abstract class MvpFragment<P extends MvpPresenter, VS extends ViewState> extends BaseFragment<VS>
+    implements MvpView {
 
     protected P presenter;
 
@@ -41,7 +42,7 @@ public abstract class MvpFragment<P extends MvpPresenter, VS extends ViewState> 
         View view = getActivity().getCurrentFocus();
         if (view != null) {
             InputMethodManager inputManager = (InputMethodManager) getActivity().getSystemService(
-                    Context.INPUT_METHOD_SERVICE);
+                Context.INPUT_METHOD_SERVICE);
             inputManager.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
         }
     }

--- a/library/src/main/java/com/vijay/jsonwizard/mvp/ViewState.java
+++ b/library/src/main/java/com/vijay/jsonwizard/mvp/ViewState.java
@@ -10,6 +10,13 @@ public class ViewState implements Parcelable {
 
     private boolean mIsSavedInstance;
 
+    public ViewState() {
+    }
+
+    protected ViewState(Parcel in) {
+        this.mIsSavedInstance = in.readByte() != 0;
+    }
+
     public boolean isSavedInstance() {
         return mIsSavedInstance;
     }
@@ -26,13 +33,6 @@ public class ViewState implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeByte(mIsSavedInstance ? (byte) 1 : (byte) 0);
-    }
-
-    public ViewState() {
-    }
-
-    protected ViewState(Parcel in) {
-        this.mIsSavedInstance = in.readByte() != 0;
     }
 
 }

--- a/library/src/main/java/com/vijay/jsonwizard/utils/CarouselAdapter.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/CarouselAdapter.java
@@ -1,14 +1,6 @@
 package com.vijay.jsonwizard.utils;
 
-import java.io.File;
-import java.util.List;
-
-import com.bumptech.glide.Glide;
-import com.vijay.jsonwizard.R;
-
 import android.graphics.BitmapFactory;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,10 +8,19 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.vijay.jsonwizard.R;
+
+import java.io.File;
+import java.util.List;
+
 /**
  * Created by xcarmona on 21/06/18.
  */
-public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHolder>{
+public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHolder> {
 
     private List<CarouselItem> data;
     private RecyclerView parentRecycler;
@@ -43,14 +44,15 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
             @Override
             public void onClick(View v) {
                 int position = parentRecycler.getChildLayoutPosition(v);
-                String imagePath =  data.get(position).getImage();
+                String imagePath = data.get(position).getImage();
                 boolean exists = (!TextUtils.isEmpty(imagePath)) && (new File(imagePath).exists());
-                if(exists){
+                if (exists) {
                     LayoutInflater factory = LayoutInflater.from(v.getContext());
                     View popupView = factory.inflate(R.layout.item_carousel_popup, null);
                     ImageView imageView = popupView.findViewById(R.id.image);
                     imageView.setImageBitmap(BitmapFactory.decodeFile(imagePath));
-                    AlertDialog.Builder builder = new AlertDialog.Builder(v.getContext(), android.R.style.Theme_DeviceDefault_NoActionBar_Fullscreen);
+                    AlertDialog.Builder builder = new AlertDialog.Builder(v.getContext(),
+                        android.R.style.Theme_DeviceDefault_NoActionBar_Fullscreen);
                     builder.setView(popupView);
                     builder.create().show();
                 }
@@ -63,20 +65,14 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
     public void onBindViewHolder(ViewHolder holder, int position) {
         String imagePath = data.get(position).getImage();
         int imageResourceId = isInteger(imagePath);
-        if(!TextUtils.isEmpty(imagePath)) {
-            if(imageResourceId>0){
-                Glide.with(holder.itemView.getContext())
-                        .load(imageResourceId)
-                        .into(holder.image);
-            }else {
-                Glide.with(holder.itemView.getContext())
-                        .load(new File(imagePath))
-                        .into(holder.image);
+        if (!TextUtils.isEmpty(imagePath)) {
+            if (imageResourceId > 0) {
+                Glide.with(holder.itemView.getContext()).load(imageResourceId).into(holder.image);
+            } else {
+                Glide.with(holder.itemView.getContext()).load(new File(imagePath)).into(holder.image);
             }
         } else {
-            Glide.with(holder.itemView.getContext())
-                    .load(R.mipmap.error_icon)
-                    .into(holder.image);
+            Glide.with(holder.itemView.getContext()).load(R.mipmap.error_icon).into(holder.image);
         }
         holder.name.setText(data.get(position).getName());
         holder.value.setText(data.get(position).getValue());
@@ -90,7 +86,7 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
     private int isInteger(String s) {
         try {
             return Integer.parseInt(s);
-        } catch(Exception e) {
+        } catch (Exception e) {
             return -1;
         }
         // only got here if we didn't return false

--- a/library/src/main/java/com/vijay/jsonwizard/utils/DateUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/DateUtils.java
@@ -19,7 +19,7 @@ public class DateUtils {
     private static final String JSON_DATE_PATTERN = "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'";
 
     public static String toJSONDateFormat(Date date) {
-        if(date == null){
+        if (date == null) {
             return null;
         }
         final DateFormat jsonSdf = new SimpleDateFormat(JSON_DATE_PATTERN);
@@ -38,10 +38,10 @@ public class DateUtils {
 
     public static Date parseDate(String date, String pattern) {
         DateFormat sdf;
-        try{
-            if(pattern == null || "".equals(pattern)){
+        try {
+            if (pattern == null || "".equals(pattern)) {
                 sdf = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
-            }else{
+            } else {
                 sdf = new SimpleDateFormat(pattern);
             }
             return sdf.parse(date);
@@ -53,9 +53,9 @@ public class DateUtils {
 
     public static String formatDate(Date date, String pattern) {
         DateFormat sdf;
-        if(pattern == null || "".equals(pattern)){
+        if (pattern == null || "".equals(pattern)) {
             sdf = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
-        }else{
+        } else {
             sdf = new SimpleDateFormat(pattern);
         }
         return sdf.format(date);

--- a/library/src/main/java/com/vijay/jsonwizard/utils/FormUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/FormUtils.java
@@ -18,14 +18,15 @@ public class FormUtils {
     public static final int MATCH_PARENT = -1;
     public static final int WRAP_CONTENT = -2;
 
-    public static LinearLayout.LayoutParams getLayoutParams(int width, int height, int left, int top, int right, int bottom) {
+    public static LinearLayout.LayoutParams getLayoutParams(int width, int height, int left, int top, int right,
+        int bottom) {
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(width, height);
         layoutParams.setMargins(left, top, right, bottom);
         return layoutParams;
     }
 
     public static TextView getTextViewWith(Context context, int textSizeInSp, String text, String key, String type,
-                                           LinearLayout.LayoutParams layoutParams, String fontPath) {
+        LinearLayout.LayoutParams layoutParams, String fontPath) {
         TextView textView = new TextView(context);
         textView.setText(text);
         textView.setTag(R.id.key, key);
@@ -38,7 +39,7 @@ public class FormUtils {
     }
 
     public static TextView getTextViewWith(Context context, int textSizeInSp, Spanned text, String key, String type,
-            LinearLayout.LayoutParams layoutParams, String fontPath) {
+        LinearLayout.LayoutParams layoutParams, String fontPath) {
         TextView textView = new TextView(context);
         textView.setText(text);
         textView.setTag(R.id.key, key);

--- a/library/src/main/java/com/vijay/jsonwizard/utils/ImageFileUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/ImageFileUtils.java
@@ -3,13 +3,6 @@ package com.vijay.jsonwizard.utils;
 
 import static android.os.Environment.getExternalStorageDirectory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.Bitmap.Config;
@@ -20,15 +13,20 @@ import android.graphics.Rect;
 import android.util.Base64;
 import android.util.Log;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
 /**
  * Created by x.carmona on 18/01/17.
  */
 public class ImageFileUtils {
 
-    private static final String TAG = "ImageFileUtils";
-
     public static final int IMAGE_MAX_SIZE = 1600;
     public static final int IMAGE_COMPRESSION_RATIO = 80;
+    private static final String TAG = "ImageFileUtils";
 
     public static String processImageFromFile(String filePath) {
         Bitmap tempImage;
@@ -62,17 +60,13 @@ public class ImageFileUtils {
         // Only scale if necessary
         if ((unscaledBitmap.getWidth() > maxSize) || (unscaledBitmap.getHeight() > maxSize)) {
 
-            Rect srcRect = calculateSrcRect(unscaledBitmap.getWidth(), unscaledBitmap.getHeight(),
-                    maxSize, maxSize,
-                    ScalingLogic.FIT);
-            Rect destRect = calculateDestRect(unscaledBitmap.getWidth(), unscaledBitmap.getHeight(),
-                    maxSize, maxSize,
-                    ScalingLogic.FIT);
-            scaledBitmap = Bitmap
-                    .createBitmap(destRect.width(), destRect.height(), Config.ARGB_8888);
+            Rect srcRect = calculateSrcRect(unscaledBitmap.getWidth(), unscaledBitmap.getHeight(), maxSize, maxSize,
+                ScalingLogic.FIT);
+            Rect destRect = calculateDestRect(unscaledBitmap.getWidth(), unscaledBitmap.getHeight(), maxSize, maxSize,
+                ScalingLogic.FIT);
+            scaledBitmap = Bitmap.createBitmap(destRect.width(), destRect.height(), Config.ARGB_8888);
             Canvas canvas = new Canvas(scaledBitmap);
-            canvas.drawBitmap(unscaledBitmap, srcRect, destRect,
-                    new Paint(Paint.FILTER_BITMAP_FLAG));
+            canvas.drawBitmap(unscaledBitmap, srcRect, destRect, new Paint(Paint.FILTER_BITMAP_FLAG));
         } else {
             scaledBitmap = unscaledBitmap;
         }
@@ -80,7 +74,7 @@ public class ImageFileUtils {
     }
 
     public static Rect calculateSrcRect(int srcWidth, int srcHeight, int dstWidth, int dstHeight,
-            ScalingLogic scalingLogic) {
+        ScalingLogic scalingLogic) {
         if (scalingLogic == ScalingLogic.CROP) {
             final float srcAspect = (float) srcWidth / (float) srcHeight;
             final float dstAspect = (float) dstWidth / (float) dstHeight;
@@ -99,8 +93,7 @@ public class ImageFileUtils {
         }
     }
 
-    public static Rect calculateDestRect(int srcWidth, int srcHeight, int dstWidth, int dstHeight,
-            ScalingLogic logic) {
+    public static Rect calculateDestRect(int srcWidth, int srcHeight, int dstWidth, int dstHeight, ScalingLogic logic) {
         if (logic == ScalingLogic.FIT) {
             final float srcAspect = (float) srcWidth / (float) srcHeight;
             final float dstAspect = (float) dstWidth / (float) dstHeight;
@@ -167,6 +160,7 @@ public class ImageFileUtils {
     }
 
     public static enum ScalingLogic {
-        CROP, FIT
+        CROP,
+        FIT
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/utils/ImagePicker.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/ImagePicker.java
@@ -1,14 +1,5 @@
 package com.vijay.jsonwizard.utils;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import com.vijay.jsonwizard.R;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -23,8 +14,18 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Parcelable;
 import android.provider.MediaStore;
-import android.support.v4.content.FileProvider;
 import android.util.Log;
+
+import androidx.core.content.FileProvider;
+
+import com.vijay.jsonwizard.R;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ImagePicker {
 
@@ -36,32 +37,28 @@ public class ImagePicker {
         Intent chooserIntent = null;
 
         List<Intent> intentList = new ArrayList<>();
-        Intent pickIntent = new Intent(Intent.ACTION_PICK, android.provider.MediaStore.Images.Media
-                .EXTERNAL_CONTENT_URI);
+        Intent pickIntent = new Intent(Intent.ACTION_PICK,
+            android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
         Intent takePhotoIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         takePhotoIntent.putExtra("return-data", true);
-        Uri uri = FileProvider
-                .getUriForFile(context, context.getApplicationContext().getPackageName(),
-                        getTempFile
-                                (context));
+        Uri uri = FileProvider.getUriForFile(context, context.getApplicationContext().getPackageName(),
+            getTempFile(context));
         takePhotoIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri);
         intentList = addIntentsToList(context, intentList, pickIntent);
         intentList = addIntentsToList(context, intentList, takePhotoIntent);
 
         if (intentList.size() > 0) {
             chooserIntent = Intent.createChooser(intentList.remove(intentList.size() - 1),
-                    context.getString(R.string.image_picker));
-            chooserIntent
-                    .putExtra(Intent.EXTRA_INITIAL_INTENTS, intentList.toArray(new Parcelable[]{}));
+                context.getString(R.string.image_picker));
+            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentList.toArray(new Parcelable[]{}));
         }
 
         return chooserIntent;
     }
 
-    private static List<Intent> addIntentsToList(Context context, List<Intent> list,
-            Intent intent) {
+    private static List<Intent> addIntentsToList(Context context, List<Intent> list, Intent intent) {
         List<ResolveInfo> resInfo = context.getPackageManager().queryIntentActivities(intent, 0);
-        for (ResolveInfo resolveInfo : resInfo) {
+        for (ResolveInfo resolveInfo: resInfo) {
             String packageName = resolveInfo.activityInfo.packageName;
             Intent targetedIntent = new Intent(intent);
             targetedIntent.setPackage(packageName);
@@ -72,21 +69,21 @@ public class ImagePicker {
     }
 
 
-    public static Bitmap getImageFromResult(Context context, int resultCode,
-            Intent imageReturnedIntent) {
+    public static Bitmap getImageFromResult(Context context, int resultCode, Intent imageReturnedIntent) {
         Log.d(TAG, "getImageFromResult, resultCode: " + resultCode);
         Bitmap bm = null;
         File imageFile = getTempFile(context);
         if (resultCode == Activity.RESULT_OK) {
             Uri selectedImage;
-            boolean isCamera = (imageReturnedIntent == null ||
-                    imageReturnedIntent.getData() == null ||
-                    imageReturnedIntent.getData().toString().contains(imageFile.toString()));
+            boolean isCamera =
+                (imageReturnedIntent == null || imageReturnedIntent.getData() == null || imageReturnedIntent.getData()
+                                                                                                            .toString()
+                                                                                                            .contains(
+                                                                                                                imageFile
+                                                                                                                    .toString()));
             if (isCamera) {
-                selectedImage = FileProvider
-                        .getUriForFile(context, context.getApplicationContext().getPackageName(),
-                                getTempFile
-                                        (context));
+                selectedImage = FileProvider.getUriForFile(context, context.getApplicationContext().getPackageName(),
+                    getTempFile(context));
             } else {
                 selectedImage = imageReturnedIntent.getData();
             }
@@ -114,10 +111,10 @@ public class ImagePicker {
             try {
                 fileDescriptor = context.getContentResolver().openAssetFileDescriptor(theUri, "r");
 
-                Bitmap actuallyUsableBitmap = BitmapFactory.decodeFileDescriptor(
-                        fileDescriptor.getFileDescriptor(), null, options);
-                Log.d(TAG, options.inSampleSize + " sample method bitmap ... " +
-                        actuallyUsableBitmap.getWidth() + " " + actuallyUsableBitmap.getHeight());
+                Bitmap actuallyUsableBitmap = BitmapFactory.decodeFileDescriptor(fileDescriptor.getFileDescriptor(),
+                    null, options);
+                Log.d(TAG, options.inSampleSize + " sample method bitmap ... " + actuallyUsableBitmap.getWidth() + " "
+                    + actuallyUsableBitmap.getHeight());
                 return actuallyUsableBitmap;
 
             } catch (FileNotFoundException e) {
@@ -171,9 +168,7 @@ public class ImagePicker {
                 exif = new ExifInterface(imageFile.getPath());
             }
 
-            int orientation = exif.getAttributeInt(
-                    ExifInterface.TAG_ORIENTATION,
-                    ExifInterface.ORIENTATION_NORMAL);
+            int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
 
             switch (orientation) {
                 case ExifInterface.ORIENTATION_ROTATE_270:
@@ -226,8 +221,7 @@ public class ImagePicker {
         if (rotation != 0) {
             Matrix matrix = new Matrix();
             matrix.postRotate(rotation);
-            return Bitmap
-                    .createBitmap(bm, 0, 0, bm.getWidth(), bm.getHeight(), matrix, true);
+            return Bitmap.createBitmap(bm, 0, 0, bm.getWidth(), bm.getHeight(), matrix, true);
         }
         return bm;
     }

--- a/library/src/main/java/com/vijay/jsonwizard/utils/ImagePickerProvider.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/ImagePickerProvider.java
@@ -1,6 +1,6 @@
 package com.vijay.jsonwizard.utils;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 public class ImagePickerProvider extends FileProvider {
 

--- a/library/src/main/java/com/vijay/jsonwizard/utils/ImageUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/ImageUtils.java
@@ -1,15 +1,16 @@
 package com.vijay.jsonwizard.utils;
 
-import java.io.File;
-import java.io.FileOutputStream;
-
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.support.v4.util.LruCache;
 import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
+
+import androidx.collection.LruCache;
+
+import java.io.File;
+import java.io.FileOutputStream;
 
 /**
  * Created by vijay.rawat01 on 7/29/15.
@@ -22,7 +23,7 @@ public class ImageUtils {
     public static Bitmap loadBitmapFromFile(String path, int requiredWidth, int requiredHeight) {
         String key = path + ":" + requiredWidth + ":" + requiredHeight;
         Bitmap bitmap = mBitmapLruCache.get(key);
-        if(bitmap != null) {
+        if (bitmap != null) {
             Log.d("ImagePickerFactory", "Found in cache.");
             return bitmap;
         }
@@ -53,8 +54,7 @@ public class ImageUtils {
             final int halfWidth = width / 2;
             // Calculate the largest inSampleSize value that is a power of 2 and keeps both
             // height and width larger than the requested height and width.
-            while ((halfHeight / inSampleSize) > reqHeight
-                    && (halfWidth / inSampleSize) > reqWidth) {
+            while ((halfHeight / inSampleSize) > reqHeight && (halfWidth / inSampleSize) > reqWidth) {
                 inSampleSize *= 2;
             }
         }
@@ -68,10 +68,10 @@ public class ImageUtils {
         return display.getWidth();
     }
 
-    public static boolean saveToFile(Bitmap bitmap, File file){
+    public static boolean saveToFile(Bitmap bitmap, File file) {
         final int COMPRESSION_RATIO = 80;
         try {
-                // Create folder if doesn't exist
+            // Create folder if doesn't exist
             File folder = new File(file.getParent());
             if (!folder.exists()) {
                 folder.mkdirs();

--- a/library/src/main/java/com/vijay/jsonwizard/utils/JsonFormUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/JsonFormUtils.java
@@ -2,19 +2,20 @@ package com.vijay.jsonwizard.utils;
 
 import android.text.TextUtils;
 import android.util.Log;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 public class JsonFormUtils {
 
     private static final String TAG = "JsonFormUtils";
 
-    public static JSONObject mergeFormData(JSONObject form, JSONObject dataJson)
-            throws JSONException {
+    public static JSONObject mergeFormData(JSONObject form, JSONObject dataJson) throws JSONException {
         JSONObject mergedForm = new JSONObject(form.toString());
 
         Iterator<String> keys = dataJson.keys();
@@ -35,8 +36,7 @@ public class JsonFormUtils {
         return extractDataFromForm(form, true);
     }
 
-    public static JSONObject extractDataFromForm(JSONObject form, boolean includeBase64)
-            throws JSONException {
+    public static JSONObject extractDataFromForm(JSONObject form, boolean includeBase64) throws JSONException {
         Map<String, Object> dataMap = new HashMap<>();
 
         JSONArray names = form.names();
@@ -79,9 +79,8 @@ public class JsonFormUtils {
         return null;
     }
 
-    private static void processFieldContainer(JSONObject container, Map<String, Object> dataMap,
-            boolean incluideBase64)
-            throws JSONException {
+    private static void processFieldContainer(JSONObject container, Map<String, Object> dataMap, boolean incluideBase64)
+        throws JSONException {
         JSONArray fields = container.optJSONArray("fields");
         if (fields != null) {
             for (int i = 0; i < fields.length(); i++) {
@@ -101,8 +100,7 @@ public class JsonFormUtils {
         }
     }
 
-    private static void processImageChooser(JSONObject field, Map<String, Object> dataMap)
-            throws JSONException {
+    private static void processImageChooser(JSONObject field, Map<String, Object> dataMap) throws JSONException {
         String imagePath = field.optString("value");
         if (!TextUtils.isEmpty(imagePath)) {
             String base64 = ImageFileUtils.processImageFromFile(imagePath);
@@ -111,8 +109,7 @@ public class JsonFormUtils {
         }
     }
 
-    private static void processCheckbox(JSONObject field, Map<String, Object> dataMap)
-            throws JSONException {
+    private static void processCheckbox(JSONObject field, Map<String, Object> dataMap) throws JSONException {
         JSONArray options = field.optJSONArray("options");
         if (options != null) {
             for (int j = 0; j < options.length(); j++) {

--- a/library/src/main/java/com/vijay/jsonwizard/validators/edittext/LengthValidator.java
+++ b/library/src/main/java/com/vijay/jsonwizard/validators/edittext/LengthValidator.java
@@ -18,12 +18,12 @@ public class LengthValidator extends METValidator {
 
     @Override
     public boolean isValid(CharSequence charSequence, boolean isEmpty) {
-        if(!isEmpty) {
-            if(charSequence.length() >= minLength && charSequence.length() <= maxLength) {
+        if (!isEmpty) {
+            if (charSequence.length() >= minLength && charSequence.length() <= maxLength) {
                 return true;
             }
             return false;
-        } else{
+        } else {
             return true;
         }
     }

--- a/library/src/main/java/com/vijay/jsonwizard/views/JsonFormFragmentView.java
+++ b/library/src/main/java/com/vijay/jsonwizard/views/JsonFormFragmentView.java
@@ -1,25 +1,26 @@
 package com.vijay.jsonwizard.views;
 
-import com.vijay.jsonwizard.demo.resources.ResourceResolver;
-import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
-import java.util.List;
-import java.util.Locale;
-
-import org.json.JSONObject;
-
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
-import android.support.v7.app.ActionBar;
-import android.support.v7.widget.Toolbar;
 import android.view.View;
 
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
+
+import com.vijay.jsonwizard.demo.resources.ResourceResolver;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.fragments.JsonFormFragment;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.mvp.MvpView;
 import com.vijay.jsonwizard.mvp.ViewState;
+
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Created by vijay on 5/14/15.
@@ -52,6 +53,8 @@ public interface JsonFormFragmentView<VS extends ViewState> extends MvpView {
     void startActivityForResult(Intent intent, int requestCode);
 
     void updateRelevantImageView(Bitmap bitmap, String imagePath, String currentKey);
+
+    void updateRelevantEditText(String currentKey, String value);
 
     void writeValue(String stepName, String key, String value);
 

--- a/library/src/main/java/com/vijay/jsonwizard/viewstates/JsonFormFragmentViewState.java
+++ b/library/src/main/java/com/vijay/jsonwizard/viewstates/JsonFormFragmentViewState.java
@@ -8,6 +8,23 @@ import com.vijay.jsonwizard.mvp.ViewState;
  * Created by vijay on 5/14/15.
  */
 public class JsonFormFragmentViewState extends ViewState implements android.os.Parcelable {
+    public static final Creator<JsonFormFragmentViewState> CREATOR = new Creator<JsonFormFragmentViewState>() {
+        public JsonFormFragmentViewState createFromParcel(Parcel source) {
+            return new JsonFormFragmentViewState(source);
+        }
+
+        public JsonFormFragmentViewState[] newArray(int size) {
+            return new JsonFormFragmentViewState[size];
+        }
+    };
+
+    public JsonFormFragmentViewState() {
+    }
+
+    private JsonFormFragmentViewState(Parcel in) {
+        super(in);
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -17,23 +34,4 @@ public class JsonFormFragmentViewState extends ViewState implements android.os.P
     public void writeToParcel(Parcel dest, int flags) {
         super.writeToParcel(dest, flags);
     }
-
-    public JsonFormFragmentViewState() {
-    }
-
-    private JsonFormFragmentViewState(Parcel in) {
-        super(in);
-    }
-
-    public static final Creator<JsonFormFragmentViewState> CREATOR = new Creator<JsonFormFragmentViewState>() {
-                                                                       public JsonFormFragmentViewState createFromParcel(
-                                                                               Parcel source) {
-                                                                           return new JsonFormFragmentViewState(source);
-                                                                       }
-
-                                                                       public JsonFormFragmentViewState[] newArray(
-                                                                               int size) {
-                                                                           return new JsonFormFragmentViewState[size];
-                                                                       }
-                                                                   };
 }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/BarcodeTextFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/BarcodeTextFactory.java
@@ -1,0 +1,239 @@
+package com.vijay.jsonwizard.widgets;
+
+import android.content.Context;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.util.Patterns;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+
+import androidx.annotation.Nullable;
+
+import com.rengwuxian.materialedittext.MaterialEditText;
+import com.rengwuxian.materialedittext.validation.RegexpValidator;
+import com.rey.material.util.ViewUtil;
+import com.vijay.jsonwizard.R;
+import com.vijay.jsonwizard.constants.JsonFormConstants;
+import com.vijay.jsonwizard.customviews.GenericTextWatcher;
+import com.vijay.jsonwizard.demo.resources.ResourceResolver;
+import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
+import com.vijay.jsonwizard.i18n.JsonFormBundle;
+import com.vijay.jsonwizard.interfaces.CommonListener;
+import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
+import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.JsonFormUtils;
+import com.vijay.jsonwizard.utils.ValidationStatus;
+import com.vijay.jsonwizard.validators.edittext.MaxLengthValidator;
+import com.vijay.jsonwizard.validators.edittext.MinLengthValidator;
+import com.vijay.jsonwizard.validators.edittext.RequiredValidator;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BarcodeTextFactory implements FormWidgetFactory {
+
+    public static ValidationStatus validate(MaterialEditText editText) {
+        boolean validate = editText.validate();
+        if (!validate) {
+            return new ValidationStatus(false, editText.getError().toString());
+        }
+        return new ValidationStatus(true, null);
+    }
+
+    @Override
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
+        List<View> views = null;
+        switch (visualizationMode) {
+            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
+                views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
+                break;
+            default:
+                views = getEditableViewsFromJson(stepName, context, jsonObject, listener, bundle, resolver);
+        }
+        return views;
+    }
+
+    private List<View> getEditableViewsFromJson(String stepName, Context context, JSONObject jsonObject,
+        CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
+
+        String readonlyValue = jsonObject.optString("readonly");
+        boolean readonly = false;
+
+        if (resolver.isValidExpression(readonlyValue)) {
+            JSONObject currentValues = getCurrentValues(context);
+            readonly = resolver.existsExpression(readonlyValue, currentValues);
+        } else {
+            readonly = Boolean.TRUE.toString().equalsIgnoreCase(readonlyValue);
+        }
+
+        if (readonly) {
+            return getReadOnlyViewsFromJson(context, jsonObject, bundle);
+        }
+
+        int minLength;
+        int maxLength;
+        List<View> views = new ArrayList<>(1);
+        View parentView = LayoutInflater.from(context).inflate(R.layout.item_barcode_edit_text, null);
+        final MaterialEditText editText = parentView.findViewById(R.id.edit_text);
+        final String hint = bundle.resolveKey(jsonObject.getString("hint"));
+        editText.setHint(hint);
+        editText.setFloatingLabelText(hint);
+        editText.setId(ViewUtil.generateViewId());
+        editText.setTag(R.id.key, jsonObject.getString("key"));
+        editText.setTag(R.id.type, jsonObject.getString("type"));
+
+        final ImageView imageView = parentView.findViewById(R.id.icon);
+        imageView.setOnClickListener(listener);
+        imageView.setTag(R.id.key, jsonObject.getString("key"));
+        imageView.setTag(R.id.type, jsonObject.getString("type"));
+
+        final String value = jsonObject.optString("value");
+        if (!TextUtils.isEmpty(value)) {
+            editText.setText(value);
+        }
+
+        if (!TextUtils.isEmpty(jsonObject.optString("lines"))) {
+            editText.setSingleLine(false);
+            editText.setLines(jsonObject.optInt("lines"));
+        }
+
+        //add validators
+        JSONObject requiredObject = jsonObject.optJSONObject("v_required");
+        if (requiredObject != null) {
+            String requiredValue = requiredObject.getString("value");
+            if (!TextUtils.isEmpty(requiredValue)) {
+                boolean required = false;
+                if (resolver.isValidExpression(requiredValue)) {
+                    JSONObject currentValues = getCurrentValues(context);
+                    required = resolver.existsExpression(requiredValue, currentValues);
+                } else {
+                    required = Boolean.TRUE.toString().equalsIgnoreCase(requiredValue);
+                }
+
+                if (required) {
+                    editText.addValidator(new RequiredValidator(bundle.resolveKey(requiredObject.getString("err"))));
+                }
+            }
+        }
+
+        JSONObject minLengthObject = jsonObject.optJSONObject("v_min_length");
+        if (minLengthObject != null) {
+            String minLengthValue = minLengthObject.optString("value");
+            if (!TextUtils.isEmpty(minLengthValue)) {
+                minLength = Integer.parseInt(minLengthValue);
+                editText.addValidator(new MinLengthValidator(bundle.resolveKey(minLengthObject.getString("err")),
+                    Integer.parseInt(minLengthValue)));
+                editText.setMinCharacters(minLength);
+            }
+        }
+
+        JSONObject maxLengthObject = jsonObject.optJSONObject("v_max_length");
+        if (maxLengthObject != null) {
+            String maxLengthValue = maxLengthObject.optString("value");
+            if (!TextUtils.isEmpty(maxLengthValue)) {
+                maxLength = Integer.parseInt(maxLengthValue);
+                editText.addValidator(new MaxLengthValidator(bundle.resolveKey(maxLengthObject.getString("err")),
+                    Integer.parseInt(maxLengthValue)));
+                editText.setMaxCharacters(maxLength);
+            }
+        }
+
+        JSONObject regexObject = jsonObject.optJSONObject("v_regex");
+        if (regexObject != null) {
+            String regexValue = regexObject.optString("value");
+            if (!TextUtils.isEmpty(regexValue)) {
+                editText.addValidator(new RegexpValidator(bundle.resolveKey(regexObject.getString("err")), regexValue));
+            }
+        }
+
+        JSONObject emailObject = jsonObject.optJSONObject("v_email");
+        if (emailObject != null) {
+            String emailValue = emailObject.optString("value");
+            if (!TextUtils.isEmpty(emailValue)) {
+                if (Boolean.TRUE.toString().equalsIgnoreCase(emailValue)) {
+                    editText.addValidator(new RegexpValidator(bundle.resolveKey(emailObject.getString("err")),
+                        android.util.Patterns.EMAIL_ADDRESS.toString()));
+                }
+            }
+        }
+
+        JSONObject urlObject = jsonObject.optJSONObject("v_url");
+        if (urlObject != null) {
+            String urlValue = urlObject.optString("value");
+            if (!TextUtils.isEmpty(urlValue)) {
+                if (Boolean.TRUE.toString().equalsIgnoreCase(urlValue)) {
+                    editText.addValidator(new RegexpValidator(bundle.resolveKey(urlObject.getString("err")),
+                        Patterns.WEB_URL.toString()));
+                }
+            }
+        }
+
+        JSONObject numericObject = jsonObject.optJSONObject("v_numeric");
+        if (numericObject != null) {
+            String numericValue = numericObject.optString("value");
+            if (!TextUtils.isEmpty(numericValue)) {
+                if (Boolean.TRUE.toString().equalsIgnoreCase(numericValue)) {
+                    editText.addValidator(
+                        new RegexpValidator(bundle.resolveKey(numericObject.getString("err")), "[0-9]+"));
+                }
+            }
+        }
+
+        // edit type check
+        String editType = jsonObject.optString("edit_type");
+        if (!TextUtils.isEmpty(editType)) {
+            if (editType.equals("number")) {
+                editText.setRawInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+            }
+        }
+
+        editText.addTextChangedListener(new GenericTextWatcher(stepName, editText));
+        views.add(parentView);
+        return views;
+    }
+
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
+        List<View> views = new ArrayList<>(1);
+        View parentView = LayoutInflater.from(context).inflate(R.layout.item_barcode_edit_text, null);
+        final MaterialEditText editText = parentView.findViewById(R.id.edit_text);
+        editText.setId(ViewUtil.generateViewId());
+        final String hint = bundle.resolveKey(jsonObject.getString("hint"));
+        editText.setHint(hint);
+        editText.setFloatingLabelText(hint);
+        editText.setTag(R.id.key, jsonObject.getString("key"));
+        editText.setTag(R.id.type, jsonObject.getString("type"));
+        editText.setText(jsonObject.optString("value"));
+
+        if (!TextUtils.isEmpty(jsonObject.optString("lines"))) {
+            editText.setSingleLine(false);
+            editText.setLines(jsonObject.optInt("lines"));
+        }
+        editText.setEnabled(false);
+
+        final ImageView imageView = parentView.findViewById(R.id.icon);
+        imageView.setClickable(false);
+        imageView.setEnabled(false);
+        imageView.setVisibility(View.GONE);
+
+        views.add(parentView);
+        return views;
+    }
+
+    @Nullable
+    private JSONObject getCurrentValues(Context context) throws JSONException {
+        JSONObject currentValues = null;
+        if (context instanceof JsonApi) {
+            String currentJsonState = ((JsonApi) context).currentJsonState();
+            JSONObject currentJsonObject = new JSONObject(currentJsonState);
+            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
+        }
+        return currentValues;
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/CarouselFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/CarouselFactory.java
@@ -2,11 +2,11 @@ package com.vijay.jsonwizard.widgets;
 
 
 import android.content.Context;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+
+import androidx.annotation.Nullable;
 
 import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rey.material.util.ViewUtil;
@@ -30,9 +30,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -44,10 +41,25 @@ public class CarouselFactory implements FormWidgetFactory {
 
     private static final String TAG = "CarouselFactory";
 
+    public static ValidationStatus validate(DiscreteScrollView dsv) {
+        if (!(dsv.getTag(R.id.v_required) instanceof String) || !(dsv.getTag(R.id.error) instanceof String)) {
+            return new ValidationStatus(true, null);
+        }
+        Boolean isRequired = Boolean.valueOf((String) dsv.getTag(R.id.v_required));
+        if (!isRequired) {
+            return new ValidationStatus(true, null);
+        }
+        int selectedItemPosition = dsv.getCurrentItem();
+        if (selectedItemPosition > 0) {
+            return new ValidationStatus(true, null);
+        }
+        return new ValidationStatus(false, (String) dsv.getTag(R.id.error));
+    }
+
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject,
-            CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
-            ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = null;
         switch (visualizationMode) {
             case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
@@ -59,14 +71,13 @@ public class CarouselFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject,
-                                                CommonListener listener, JsonFormBundle bundle,
-                                                JsonExpressionResolver resolver, ResourceResolver resourceResolver)
-            throws JSONException {
+    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
 
-        DiscreteScrollView scrollView = (DiscreteScrollView) LayoutInflater.from(context)
-                .inflate(R.layout.item_carousel, null);
+        DiscreteScrollView scrollView = (DiscreteScrollView) LayoutInflater.from(context).inflate(
+            R.layout.item_carousel, null);
 
         scrollView.setId(ViewUtil.generateViewId());
 
@@ -120,8 +131,7 @@ public class CarouselFactory implements FormWidgetFactory {
 
         String otherOption = bundle.resolveKey(jsonObject.optString("other"));
         String chooseOption = bundle.resolveKey(jsonObject.optString("hint"));
-        chooseOption = (TextUtils.isEmpty(chooseOption)) ? context.getString(R.string.image_picker)
-                : chooseOption;
+        chooseOption = (TextUtils.isEmpty(chooseOption)) ? context.getString(R.string.image_picker) : chooseOption;
 
         //Add choose option
         listValues.add(0, null);
@@ -143,7 +153,7 @@ public class CarouselFactory implements FormWidgetFactory {
             List<CarouselItem> data = new ArrayList<>();
             for (int i = 0; i < listValues.size(); i++) {
                 String imagePath = listImages.get(i);
-                if(!isInteger(imagePath)){
+                if (!isInteger(imagePath)) {
                     imagePath = resourceResolver.resolvePath(context, imagePath);
                 }
                 data.add(new CarouselItem(listNames.get(i), listValues.get(i), imagePath));
@@ -199,8 +209,7 @@ public class CarouselFactory implements FormWidgetFactory {
         return indexToSelect;
     }
 
-    private String getValuesAsJsonExpression(JSONObject jsonObject,
-            JsonExpressionResolver resolver) {
+    private String getValuesAsJsonExpression(JSONObject jsonObject, JsonExpressionResolver resolver) {
         String valuesExpression = jsonObject.optString("values");
         if (resolver.isValidExpression(valuesExpression)) {
             return valuesExpression;
@@ -208,8 +217,7 @@ public class CarouselFactory implements FormWidgetFactory {
         return null;
     }
 
-    private String getImagesAsJsonExpression(JSONObject jsonObject,
-            JsonExpressionResolver resolver) {
+    private String getImagesAsJsonExpression(JSONObject jsonObject, JsonExpressionResolver resolver) {
         String valuesExpression = jsonObject.optString("images");
         if (resolver.isValidExpression(valuesExpression)) {
             return valuesExpression;
@@ -217,11 +225,10 @@ public class CarouselFactory implements FormWidgetFactory {
         return null;
     }
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject)
-            throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject) throws JSONException {
         List<View> views = new ArrayList<>(1);
-        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(R.layout.item_edit_text,
+            null);
         editText.setId(ViewUtil.generateViewId());
         final String hint = jsonObject.getString("hint");
         editText.setHint(hint);
@@ -233,22 +240,6 @@ public class CarouselFactory implements FormWidgetFactory {
         editText.setEnabled(false);
         views.add(editText);
         return views;
-    }
-
-    public static ValidationStatus validate(DiscreteScrollView dsv) {
-        if (!(dsv.getTag(R.id.v_required) instanceof String) || !(dsv
-                .getTag(R.id.error) instanceof String)) {
-            return new ValidationStatus(true, null);
-        }
-        Boolean isRequired = Boolean.valueOf((String) dsv.getTag(R.id.v_required));
-        if (!isRequired) {
-            return new ValidationStatus(true, null);
-        }
-        int selectedItemPosition = dsv.getCurrentItem();
-        if (selectedItemPosition > 0) {
-            return new ValidationStatus(true, null);
-        }
-        return new ValidationStatus(false, (String) dsv.getTag(R.id.error));
     }
 
     private boolean isInteger(String s) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/CheckBoxFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/CheckBoxFactory.java
@@ -1,14 +1,21 @@
 package com.vijay.jsonwizard.widgets;
 
+import static com.vijay.jsonwizard.utils.FormUtils.FONT_BOLD_PATH;
+import static com.vijay.jsonwizard.utils.FormUtils.FONT_REGULAR_PATH;
+import static com.vijay.jsonwizard.utils.FormUtils.MATCH_PARENT;
+import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
+import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
+import static com.vijay.jsonwizard.utils.FormUtils.getTextViewWith;
+
 import android.content.Context;
 import android.graphics.Typeface;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.LinearLayout;
+
+import androidx.annotation.Nullable;
 
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
@@ -18,17 +25,15 @@ import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
-
 import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.vijay.jsonwizard.utils.FormUtils.*;
 
 /**
  * Created by vijay on 24-05-2015.
@@ -38,9 +43,9 @@ public class CheckBoxFactory implements FormWidgetFactory {
     private static final String TAG = "CheckBoxFactory";
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject,
-                                       CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
-                                       ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = null;
         switch (visualizationMode) {
             case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
@@ -52,37 +57,31 @@ public class CheckBoxFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject,
-            CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver)
-            throws JSONException {
+    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
         List<View> views = new ArrayList<>(1);
-        views.add(getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")),
-                jsonObject.getString("key"),
-                jsonObject.getString("type"),
-                getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0),
-                FONT_BOLD_PATH));
+        views.add(
+            getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")), jsonObject.getString("key"),
+                jsonObject.getString("type"), getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0), FONT_BOLD_PATH));
         JSONArray options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
         for (int i = 0; i < options.length(); i++) {
             JSONObject item = options.getJSONObject(i);
             if (isVisible(item, context, resolver)) {
-                CheckBox checkBox = (CheckBox) LayoutInflater.from(context)
-                        .inflate(R.layout.item_checkbox, null);
+                CheckBox checkBox = (CheckBox) LayoutInflater.from(context).inflate(R.layout.item_checkbox, null);
                 checkBox.setText(bundle.resolveKey(item.getString("text")));
                 checkBox.setTag(R.id.key, jsonObject.getString("key"));
                 checkBox.setTag(R.id.type, jsonObject.getString("type"));
                 checkBox.setTag(R.id.childKey, item.getString("key"));
                 checkBox.setGravity(Gravity.CENTER_VERTICAL);
                 checkBox.setTextSize(16);
-                checkBox.setTypeface(
-                        Typeface.createFromAsset(context.getAssets(), FONT_REGULAR_PATH));
+                checkBox.setTypeface(Typeface.createFromAsset(context.getAssets(), FONT_REGULAR_PATH));
                 checkBox.setOnCheckedChangeListener(listener);
                 if (!TextUtils.isEmpty(item.optString("value"))) {
                     checkBox.setChecked(item.optBoolean("value"));
                 }
                 if (i == options.length() - 1) {
-                    checkBox.setLayoutParams(
-                            getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, (int) context
-                                    .getResources().getDimension(R.dimen.extra_bottom_margin)));
+                    checkBox.setLayoutParams(getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0,
+                        (int) context.getResources().getDimension(R.dimen.extra_bottom_margin)));
                 }
                 views.add(checkBox);
             }
@@ -90,36 +89,30 @@ public class CheckBoxFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject,
-            JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle,
+        JsonExpressionResolver resolver) throws JSONException {
         List<View> views = new ArrayList<>(1);
-        views.add(getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")),
-                jsonObject.getString("key"),
-                jsonObject.getString("type"),
-                getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, (int) context
-                        .getResources().getDimension(R.dimen.extra_bottom_margin)),
-                FONT_BOLD_PATH));
+        views.add(
+            getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")), jsonObject.getString("key"),
+                jsonObject.getString("type"), getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0,
+                    (int) context.getResources().getDimension(R.dimen.extra_bottom_margin)), FONT_BOLD_PATH));
         JSONArray options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
         for (int i = 0; i < options.length(); i++) {
             JSONObject item = options.getJSONObject(i);
             if (isVisible(item, context, resolver)) {
                 if (!TextUtils.isEmpty(item.optString("value")) && item.optBoolean("value")) {
                     views.add(
-                            getTextViewWith(context, 16, bundle.resolveKey(item.getString("text")),
-                                    item.getString("key"),
-                                    null, getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0,
-                                            (int) context
-                                                    .getResources()
-                                                    .getDimension(R.dimen.default_bottom_margin)),
-                                    FONT_REGULAR_PATH));
+                        getTextViewWith(context, 16, bundle.resolveKey(item.getString("text")), item.getString("key"),
+                            null, getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0,
+                                (int) context.getResources().getDimension(R.dimen.default_bottom_margin)),
+                            FONT_REGULAR_PATH));
                 }
             }
         }
         return views;
     }
 
-    private boolean isVisible(JSONObject jsonObject, Context context,
-            JsonExpressionResolver resolver) {
+    private boolean isVisible(JSONObject jsonObject, Context context, JsonExpressionResolver resolver) {
 
         final String showExpression = jsonObject.optString("show");
         if (TextUtils.isEmpty(showExpression)) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/DatePickerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/DatePickerFactory.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+
 import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rey.material.app.DatePickerDialog;
 import com.rey.material.app.Dialog;
@@ -20,16 +21,15 @@ import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.utils.DateUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.w3c.dom.Text;
 
 /**
  * Created by jurkiri on 16/11/17.
@@ -39,11 +39,21 @@ public class DatePickerFactory implements FormWidgetFactory {
 
     private static final String TAG = "DatePickerFactory";
 
+    public static ValidationStatus validate(MaterialEditText editText) {
+        boolean validate = editText.validate();
+        if (!validate) {
+            return new ValidationStatus(false, editText.getError().toString());
+        }
+        return new ValidationStatus(true, null);
+    }
+
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = null;
-        switch (visualizationMode){
-            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :
+        switch (visualizationMode) {
+            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
                 views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
                 break;
             default:
@@ -52,10 +62,11 @@ public class DatePickerFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle) throws JSONException {
+    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
         final MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+            R.layout.item_edit_text, null);
         final String hint = bundle.resolveKey(jsonObject.getString("hint"));
         final String minDate = jsonObject.optString("minDate");
         final String maxDate = jsonObject.optString("maxDate");
@@ -84,10 +95,11 @@ public class DatePickerFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle) throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
         final MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+            R.layout.item_edit_text, null);
         final String hint = bundle.resolveKey(jsonObject.getString("hint"));
 
         editText.setHint(hint);
@@ -110,26 +122,18 @@ public class DatePickerFactory implements FormWidgetFactory {
         return views;
     }
 
-    public static ValidationStatus validate(MaterialEditText editText) {
-        boolean validate = editText.validate();
-        if(!validate) {
-            return new ValidationStatus(false, editText.getError().toString());
-        }
-        return new ValidationStatus(true, null);
-    }
-
     private class DatePickerListener implements View.OnFocusChangeListener, View.OnClickListener {
 
         private Dialog d;
         private MaterialEditText dateText;
 
-        public DatePickerListener(MaterialEditText editText){
+        public DatePickerListener(MaterialEditText editText) {
             this.dateText = editText;
         }
 
         @Override
         public void onFocusChange(View view, boolean focus) {
-            if(focus){
+            if (focus) {
                 openDatePicker(view);
             }
         }
@@ -142,10 +146,10 @@ public class DatePickerFactory implements FormWidgetFactory {
         private void openDatePicker(View view) {
             Date date = new Date();
             String dateStr = dateText.getText().toString();
-            if(dateStr != null && !"".equals(dateStr)){
+            if (dateStr != null && !"".equals(dateStr)) {
                 try {
                     date = SimpleDateFormat.getDateInstance().parse(dateStr);
-                } catch (ParseException e){
+                } catch (ParseException e) {
                     Log.e(TAG, "Error parsing " + dateStr + ": " + e.getMessage());
                 }
             }
@@ -156,8 +160,9 @@ public class DatePickerFactory implements FormWidgetFactory {
             Date minDate = resolveDate(minDateStr, pattern);
             Date maxDate = resolveDate(maxDateStr, pattern);
 
-            DatePickerDialog.Builder builder = new DatePickerDialog.Builder(R.style.Material_App_Dialog_DatePicker).date(date.getTime());
-            if(minDate != null && maxDate != null){
+            DatePickerDialog.Builder builder = new DatePickerDialog.Builder(R.style.Material_App_Dialog_DatePicker)
+                .date(date.getTime());
+            if (minDate != null && maxDate != null) {
                 builder.dateRange(minDate.getTime(), maxDate.getTime());
             }
             d = builder.build(view.getContext());
@@ -165,7 +170,7 @@ public class DatePickerFactory implements FormWidgetFactory {
             d.positiveActionClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    Date date = new Date(((DatePickerDialog)d).getDate());
+                    Date date = new Date(((DatePickerDialog) d).getDate());
                     dateText.setText(DateUtils.formatDate(date, (String) dateText.getTag(R.id.v_pattern)));
                     d.hide();
                 }
@@ -184,14 +189,14 @@ public class DatePickerFactory implements FormWidgetFactory {
 
         private Date resolveDate(String dateStr, String pattern) {
             DateFormat sdf;
-            if(TextUtils.isEmpty(pattern)){
+            if (TextUtils.isEmpty(pattern)) {
                 sdf = SimpleDateFormat.getDateInstance();
-            }else{
+            } else {
                 sdf = new SimpleDateFormat(pattern);
             }
             try {
                 return sdf.parse(dateStr);
-            } catch (ParseException e){
+            } catch (ParseException e) {
                 Log.e(TAG, "Error parsing " + dateStr + ": " + e.getMessage());
             }
             return null;

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/EditGroupFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/EditGroupFactory.java
@@ -1,5 +1,11 @@
 package com.vijay.jsonwizard.widgets;
 
+import static com.vijay.jsonwizard.utils.FormUtils.FONT_BOLD_PATH;
+import static com.vijay.jsonwizard.utils.FormUtils.MATCH_PARENT;
+import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
+import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
+import static com.vijay.jsonwizard.utils.FormUtils.getTextViewWith;
+
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.Log;
@@ -22,12 +28,6 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.vijay.jsonwizard.utils.FormUtils.FONT_BOLD_PATH;
-import static com.vijay.jsonwizard.utils.FormUtils.MATCH_PARENT;
-import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
-import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
-import static com.vijay.jsonwizard.utils.FormUtils.getTextViewWith;
-
 /**
  * Created by jurkiri on 22/11/17.
  */
@@ -37,22 +37,24 @@ public class EditGroupFactory implements FormWidgetFactory {
     private static final String TAG = "EditGroupFactory";
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject parentJson, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject parentJson, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> viewsFromJson = new ArrayList<>();
 
         LinearLayout linearLayout = new LinearLayout(context);
-        linearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        linearLayout.setLayoutParams(
+            new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         linearLayout.setOrientation(LinearLayout.HORIZONTAL);
         linearLayout.setTag(R.id.key, parentJson.getString("key"));
         linearLayout.setTag(R.id.type, JsonFormConstants.EDIT_GROUP);
 
 
-
         String groupTitle = bundle.resolveKey(parentJson.optString("title"));
         if (!TextUtils.isEmpty(groupTitle)) {
-            viewsFromJson.add(getTextViewWith(context, 16, groupTitle, parentJson.getString("key"),
-                    parentJson.getString("type"), getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0),
-                    FONT_BOLD_PATH));
+            viewsFromJson.add(
+                getTextViewWith(context, 16, groupTitle, parentJson.getString("key"), parentJson.getString("type"),
+                    getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0), FONT_BOLD_PATH));
         }
 
         try {
@@ -62,17 +64,19 @@ public class EditGroupFactory implements FormWidgetFactory {
             for (int i = 0; i < optNumber; i++) {
                 JSONObject childJson = fields.getJSONObject(i);
                 try {
-                    List<View> views = WidgetFactoryRegistry.getWidgetFactory(childJson.getString("type")).getViewsFromJson(stepName, context, childJson, listener, bundle, resolver, resourceResolver, visualizationMode);
-                    for (View v : views) {
-                        LinearLayout.LayoutParams layoutParams=new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
-                        layoutParams.setMargins(0,0,10,0);
+                    List<View> views = WidgetFactoryRegistry.getWidgetFactory(childJson.getString("type"))
+                                                            .getViewsFromJson(stepName, context, childJson, listener,
+                                                                bundle, resolver, resourceResolver, visualizationMode);
+                    for (View v: views) {
+                        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(0,
+                            LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
+                        layoutParams.setMargins(0, 0, 10, 0);
                         v.setLayoutParams(layoutParams);
                         linearLayout.addView(v);
                     }
                 } catch (Exception e) {
-                    Log.e(TAG,
-                            "Exception occurred in making child view at index : " + i + " : Exception is : "
-                                    + e.getMessage());
+                    Log.e(TAG, "Exception occurred in making child view at index : " + i + " : Exception is : " + e
+                        .getMessage());
                 }
             }
         } catch (JSONException e) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/EditTextFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/EditTextFactory.java
@@ -1,12 +1,13 @@
 package com.vijay.jsonwizard.widgets;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.util.Patterns;
 import android.view.LayoutInflater;
 import android.view.View;
+
+import androidx.annotation.Nullable;
 
 import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rengwuxian.materialedittext.validation.RegexpValidator;
@@ -37,10 +38,18 @@ import java.util.List;
  */
 public class EditTextFactory implements FormWidgetFactory {
 
+    public static ValidationStatus validate(MaterialEditText editText) {
+        boolean validate = editText.validate();
+        if (!validate) {
+            return new ValidationStatus(false, editText.getError().toString());
+        }
+        return new ValidationStatus(true, null);
+    }
+
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject,
-                                       CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
-                                       ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = null;
         switch (visualizationMode) {
             case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
@@ -52,9 +61,8 @@ public class EditTextFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(String stepName, Context context,
-            JSONObject jsonObject, JsonFormBundle bundle, JsonExpressionResolver resolver)
-            throws JSONException {
+    private List<View> getEditableViewsFromJson(String stepName, Context context, JSONObject jsonObject,
+        JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
 
         String readonlyValue = jsonObject.optString("readonly");
         boolean readonly = false;
@@ -73,8 +81,8 @@ public class EditTextFactory implements FormWidgetFactory {
         int minLength;
         int maxLength;
         List<View> views = new ArrayList<>(1);
-        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(R.layout.item_edit_text,
+            null);
         final String hint = bundle.resolveKey(jsonObject.getString("hint"));
         editText.setHint(hint);
         editText.setFloatingLabelText(hint);
@@ -106,8 +114,7 @@ public class EditTextFactory implements FormWidgetFactory {
                 }
 
                 if (required) {
-                    editText.addValidator(new RequiredValidator(
-                            bundle.resolveKey(requiredObject.getString("err"))));
+                    editText.addValidator(new RequiredValidator(bundle.resolveKey(requiredObject.getString("err"))));
                 }
             }
         }
@@ -117,9 +124,8 @@ public class EditTextFactory implements FormWidgetFactory {
             String minLengthValue = minLengthObject.optString("value");
             if (!TextUtils.isEmpty(minLengthValue)) {
                 minLength = Integer.parseInt(minLengthValue);
-                editText.addValidator(
-                        new MinLengthValidator(bundle.resolveKey(minLengthObject.getString("err")),
-                                Integer.parseInt(minLengthValue)));
+                editText.addValidator(new MinLengthValidator(bundle.resolveKey(minLengthObject.getString("err")),
+                    Integer.parseInt(minLengthValue)));
                 editText.setMinCharacters(minLength);
             }
         }
@@ -129,9 +135,8 @@ public class EditTextFactory implements FormWidgetFactory {
             String maxLengthValue = maxLengthObject.optString("value");
             if (!TextUtils.isEmpty(maxLengthValue)) {
                 maxLength = Integer.parseInt(maxLengthValue);
-                editText.addValidator(
-                        new MaxLengthValidator(bundle.resolveKey(maxLengthObject.getString("err")),
-                                Integer.parseInt(maxLengthValue)));
+                editText.addValidator(new MaxLengthValidator(bundle.resolveKey(maxLengthObject.getString("err")),
+                    Integer.parseInt(maxLengthValue)));
                 editText.setMaxCharacters(maxLength);
             }
         }
@@ -140,9 +145,7 @@ public class EditTextFactory implements FormWidgetFactory {
         if (regexObject != null) {
             String regexValue = regexObject.optString("value");
             if (!TextUtils.isEmpty(regexValue)) {
-                editText.addValidator(
-                        new RegexpValidator(bundle.resolveKey(regexObject.getString("err")),
-                                regexValue));
+                editText.addValidator(new RegexpValidator(bundle.resolveKey(regexObject.getString("err")), regexValue));
             }
         }
 
@@ -151,9 +154,8 @@ public class EditTextFactory implements FormWidgetFactory {
             String emailValue = emailObject.optString("value");
             if (!TextUtils.isEmpty(emailValue)) {
                 if (Boolean.TRUE.toString().equalsIgnoreCase(emailValue)) {
-                    editText.addValidator(
-                            new RegexpValidator(bundle.resolveKey(emailObject.getString("err")),
-                                    android.util.Patterns.EMAIL_ADDRESS.toString()));
+                    editText.addValidator(new RegexpValidator(bundle.resolveKey(emailObject.getString("err")),
+                        android.util.Patterns.EMAIL_ADDRESS.toString()));
                 }
             }
         }
@@ -163,9 +165,8 @@ public class EditTextFactory implements FormWidgetFactory {
             String urlValue = urlObject.optString("value");
             if (!TextUtils.isEmpty(urlValue)) {
                 if (Boolean.TRUE.toString().equalsIgnoreCase(urlValue)) {
-                    editText.addValidator(
-                            new RegexpValidator(bundle.resolveKey(urlObject.getString("err")),
-                                    Patterns.WEB_URL.toString()));
+                    editText.addValidator(new RegexpValidator(bundle.resolveKey(urlObject.getString("err")),
+                        Patterns.WEB_URL.toString()));
                 }
             }
         }
@@ -176,8 +177,7 @@ public class EditTextFactory implements FormWidgetFactory {
             if (!TextUtils.isEmpty(numericValue)) {
                 if (Boolean.TRUE.toString().equalsIgnoreCase(numericValue)) {
                     editText.addValidator(
-                            new RegexpValidator(bundle.resolveKey(numericObject.getString("err")),
-                                    "[0-9]+"));
+                        new RegexpValidator(bundle.resolveKey(numericObject.getString("err")), "[0-9]+"));
                 }
             }
         }
@@ -186,8 +186,7 @@ public class EditTextFactory implements FormWidgetFactory {
         String editType = jsonObject.optString("edit_type");
         if (!TextUtils.isEmpty(editType)) {
             if (editType.equals("number")) {
-                editText.setRawInputType(
-                        InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+                editText.setRawInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
             }
         }
 
@@ -196,11 +195,11 @@ public class EditTextFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject,
-            JsonFormBundle bundle) throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
-        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(R.layout.item_edit_text,
+            null);
         editText.setId(ViewUtil.generateViewId());
         final String hint = bundle.resolveKey(jsonObject.getString("hint"));
         editText.setHint(hint);
@@ -216,14 +215,6 @@ public class EditTextFactory implements FormWidgetFactory {
         editText.setEnabled(false);
         views.add(editText);
         return views;
-    }
-
-    public static ValidationStatus validate(MaterialEditText editText) {
-        boolean validate = editText.validate();
-        if (!validate) {
-            return new ValidationStatus(false, editText.getError().toString());
-        }
-        return new ValidationStatus(true, null);
     }
 
     @Nullable

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/ExtendedLabelFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/ExtendedLabelFactory.java
@@ -1,10 +1,12 @@
 package com.vijay.jsonwizard.widgets;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+
+import androidx.annotation.Nullable;
+
 import com.rey.material.util.ViewUtil;
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.demo.resources.ResourceResolver;
@@ -14,14 +16,16 @@ import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.sufficientlysecure.htmltextview.HtmlAssetsImageGetter;
 import org.sufficientlysecure.htmltextview.HtmlTextView;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by vijay on 24-05-2015.
@@ -32,20 +36,17 @@ public class ExtendedLabelFactory implements FormWidgetFactory {
     private static final String PARAMS_FIELD = "params";
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject,
-                                       CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
-                                       ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
-        return getAsLabel(stepName, context, jsonObject, listener, bundle, resolver,
-                visualizationMode);
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
+        return getAsLabel(stepName, context, jsonObject, listener, bundle, resolver, visualizationMode);
     }
 
-    private List<View> getAsLabel(String stepName, Context context, JSONObject jsonObject,
-            CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver,
-            int visualizationMode) throws JSONException {
+    private List<View> getAsLabel(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = new ArrayList<>(1);
 
-        HtmlTextView textView = (HtmlTextView) LayoutInflater.from(context)
-                .inflate(R.layout.item_extended_label, null);
+        HtmlTextView textView = (HtmlTextView) LayoutInflater.from(context).inflate(R.layout.item_extended_label, null);
         textView.setId(ViewUtil.generateViewId());
 
 
@@ -97,8 +98,7 @@ public class ExtendedLabelFactory implements FormWidgetFactory {
         return currentValues;
     }
 
-    private String getValuesAsJsonExpression(JSONObject jsonObject,
-            JsonExpressionResolver resolver) {
+    private String getValuesAsJsonExpression(JSONObject jsonObject, JsonExpressionResolver resolver) {
         String valuesExpression = jsonObject.optString(TEXT_FIELD);
         if (resolver.isValidExpression(valuesExpression)) {
             return valuesExpression;

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/ImagePickerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/ImagePickerFactory.java
@@ -1,5 +1,10 @@
 package com.vijay.jsonwizard.widgets;
 
+import static com.vijay.jsonwizard.utils.FormUtils.MATCH_PARENT;
+import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
+import static com.vijay.jsonwizard.utils.FormUtils.dpToPixels;
+import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
+
 import android.content.Context;
 import android.text.TextUtils;
 import android.view.View;
@@ -21,18 +26,31 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.vijay.jsonwizard.utils.FormUtils.MATCH_PARENT;
-import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
-import static com.vijay.jsonwizard.utils.FormUtils.dpToPixels;
-import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
-
 /**
  * Created by vijay on 24-05-2015.
  */
 public class ImagePickerFactory implements FormWidgetFactory {
 
+    public static ValidationStatus validate(ImageView imageView) {
+        if (!(imageView.getTag(R.id.v_required) instanceof String) || !(imageView.getTag(
+            R.id.error) instanceof String)) {
+            return new ValidationStatus(true, null);
+        }
+        Boolean isRequired = Boolean.valueOf((String) imageView.getTag(R.id.v_required));
+        if (!isRequired) {
+            return new ValidationStatus(true, null);
+        }
+        Object path = imageView.getTag(R.id.imagePath);
+        if (path instanceof String && !TextUtils.isEmpty((String) path)) {
+            return new ValidationStatus(true, null);
+        }
+        return new ValidationStatus(false, (String) imageView.getTag(R.id.error));
+    }
+
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = new ArrayList<>(1);
         ImageView imageView = new ImageView(context);
         imageView.setImageDrawable(context.getResources().getDrawable(R.mipmap.grey_bg));
@@ -49,37 +67,23 @@ public class ImagePickerFactory implements FormWidgetFactory {
         }
 
         imageView.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
-        imageView.setLayoutParams(getLayoutParams(MATCH_PARENT, dpToPixels(context, 200), 0, 0, 0, (int) context
-                .getResources().getDimension(R.dimen.default_bottom_margin)));
+        imageView.setLayoutParams(getLayoutParams(MATCH_PARENT, dpToPixels(context, 200), 0, 0, 0,
+            (int) context.getResources().getDimension(R.dimen.default_bottom_margin)));
         String imagePath = jsonObject.optString("value");
         if (!TextUtils.isEmpty(imagePath)) {
             imageView.setTag(R.id.imagePath, imagePath);
-            imageView.setImageBitmap(ImageUtils.loadBitmapFromFile(imagePath, ImageUtils.getDeviceWidth(context), dpToPixels(context, 200)));
+            imageView.setImageBitmap(
+                ImageUtils.loadBitmapFromFile(imagePath, ImageUtils.getDeviceWidth(context), dpToPixels(context, 200)));
         }
         views.add(imageView);
         Button uploadButton = new Button(context);
         uploadButton.setText(bundle.resolveKey(jsonObject.getString("uploadButtonText")));
-        uploadButton.setLayoutParams(getLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 0, 0, 0, (int) context
-                .getResources().getDimension(R.dimen.default_bottom_margin)));
+        uploadButton.setLayoutParams(getLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 0, 0, 0,
+            (int) context.getResources().getDimension(R.dimen.default_bottom_margin)));
         uploadButton.setOnClickListener(listener);
         uploadButton.setTag(R.id.key, jsonObject.getString("key"));
         uploadButton.setTag(R.id.type, jsonObject.getString("type"));
         views.add(uploadButton);
         return views;
-    }
-
-    public static ValidationStatus validate(ImageView imageView) {
-        if (!(imageView.getTag(R.id.v_required) instanceof String) || !(imageView.getTag(R.id.error) instanceof String)) {
-            return new ValidationStatus(true, null);
-        }
-        Boolean isRequired = Boolean.valueOf((String) imageView.getTag(R.id.v_required));
-        if (!isRequired) {
-            return new ValidationStatus(true, null);
-        }
-        Object path = imageView.getTag(R.id.imagePath);
-        if (path instanceof String && !TextUtils.isEmpty((String) path)) {
-            return new ValidationStatus(true, null);
-        }
-        return new ValidationStatus(false, (String) imageView.getTag(R.id.error));
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/LabelFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/LabelFactory.java
@@ -1,12 +1,19 @@
 package com.vijay.jsonwizard.widgets;
 
+import static com.vijay.jsonwizard.utils.FormUtils.FONT_BOLD_PATH;
+import static com.vijay.jsonwizard.utils.FormUtils.FONT_REGULAR_PATH;
+import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
+import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
+import static com.vijay.jsonwizard.utils.FormUtils.getTextViewWith;
+
 import android.content.Context;
-import android.support.annotation.Nullable;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
+
+import androidx.annotation.Nullable;
 
 import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rey.material.util.ViewUtil;
@@ -16,21 +23,14 @@ import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
-
 import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
-import org.json.JSONArray;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.vijay.jsonwizard.utils.FormUtils.FONT_BOLD_PATH;
-import static com.vijay.jsonwizard.utils.FormUtils.FONT_REGULAR_PATH;
-import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
-import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
-import static com.vijay.jsonwizard.utils.FormUtils.getTextViewWith;
 
 /**
  * Created by vijay on 24-05-2015.
@@ -44,20 +44,21 @@ public class LabelFactory implements FormWidgetFactory {
     private static final String BOLD_FIELD = "bold";
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         if (TextUtils.isEmpty(jsonObject.optString(HINT_FIELD))) {
-            return getAsLabel(stepName, context, jsonObject, listener, bundle, resolver,
-                    visualizationMode);
+            return getAsLabel(stepName, context, jsonObject, listener, bundle, resolver, visualizationMode);
         } else {
-            return getAsReadOnlyEditText(stepName, context, jsonObject, listener, bundle, resolver,
-                    visualizationMode);
+            return getAsReadOnlyEditText(stepName, context, jsonObject, listener, bundle, resolver, visualizationMode);
         }
     }
 
-    private List<View> getAsLabel(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode)  throws JSONException {
+    private List<View> getAsLabel(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
         List<View> views = new ArrayList<>(1);
-        LinearLayout.LayoutParams layoutParams = getLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 0, 0 , 0, (int) context
-                .getResources().getDimension(R.dimen.default_bottom_margin));
+        LinearLayout.LayoutParams layoutParams = getLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 0, 0, 0,
+            (int) context.getResources().getDimension(R.dimen.default_bottom_margin));
 
         String valuesExpression = getValuesAsJsonExpression(jsonObject, resolver);
 
@@ -66,22 +67,24 @@ public class LabelFactory implements FormWidgetFactory {
             textValue = bundle.resolveKey(jsonObject.getString(TEXT_FIELD));
         } else {
             JSONObject currentValues = getCurrentValues(context);
-            textValue = resolver.resolveAsString(valuesExpression,currentValues);
+            textValue = resolver.resolveAsString(valuesExpression, currentValues);
         }
 
-        boolean bold = jsonObject.optBoolean(BOLD_FIELD,true);
+        boolean bold = jsonObject.optBoolean(BOLD_FIELD, true);
 
-        views.add(getTextViewWith(context, 16,Html.fromHtml(textValue), jsonObject.getString(KEY_FIELD),
-                jsonObject.getString(TYPE_FIELD), layoutParams, bold?FONT_BOLD_PATH:FONT_REGULAR_PATH));
+        views.add(getTextViewWith(context, 16, Html.fromHtml(textValue), jsonObject.getString(KEY_FIELD),
+            jsonObject.getString(TYPE_FIELD), layoutParams, bold ? FONT_BOLD_PATH : FONT_REGULAR_PATH));
 
         return views;
     }
 
-    private List<View> getAsReadOnlyEditText(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle,JsonExpressionResolver resolver, int visualizationMode) throws JSONException {
+    private List<View> getAsReadOnlyEditText(String stepName, Context context, JSONObject jsonObject,
+        CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, int visualizationMode)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
 
-        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(R.layout.item_edit_text,
+            null);
         editText.setId(ViewUtil.generateViewId());
         final String hint = bundle.resolveKey(jsonObject.getString(HINT_FIELD));
         editText.setHint(hint);
@@ -96,7 +99,7 @@ public class LabelFactory implements FormWidgetFactory {
             textValue = bundle.resolveKey(jsonObject.getString(TEXT_FIELD));
         } else {
             JSONObject currentValues = getCurrentValues(context);
-            textValue = resolver.resolveAsString(valuesExpression,currentValues);
+            textValue = resolver.resolveAsString(valuesExpression, currentValues);
         }
 
         editText.setText(Html.fromHtml(textValue));
@@ -112,7 +115,7 @@ public class LabelFactory implements FormWidgetFactory {
         if (context instanceof JsonApi) {
             String currentJsonState = ((JsonApi) context).currentJsonState();
             JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues =  JsonFormUtils.extractDataFromForm(currentJsonObject,false);
+            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
         }
         return currentValues;
     }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/RadioButtonFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/RadioButtonFactory.java
@@ -1,13 +1,21 @@
 package com.vijay.jsonwizard.widgets;
 
+import static com.vijay.jsonwizard.utils.FormUtils.FONT_BOLD_PATH;
+import static com.vijay.jsonwizard.utils.FormUtils.FONT_REGULAR_PATH;
+import static com.vijay.jsonwizard.utils.FormUtils.MATCH_PARENT;
+import static com.vijay.jsonwizard.utils.FormUtils.WRAP_CONTENT;
+import static com.vijay.jsonwizard.utils.FormUtils.getLayoutParams;
+import static com.vijay.jsonwizard.utils.FormUtils.getTextViewWith;
+
 import android.content.Context;
 import android.graphics.Typeface;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.RadioGroup;
+
+import androidx.annotation.Nullable;
 
 import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rey.material.util.ViewUtil;
@@ -19,17 +27,15 @@ import com.vijay.jsonwizard.expressions.JsonExpressionResolver;
 import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
-
 import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.vijay.jsonwizard.utils.FormUtils.*;
 
 /**
  * Created by vijay on 24-05-2015.
@@ -39,23 +45,26 @@ public class RadioButtonFactory implements FormWidgetFactory {
     private final String H_ORIENTATION_VALUE = "horizontal";
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = null;
-        switch (visualizationMode){
-            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :
+        switch (visualizationMode) {
+            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
                 views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
                 break;
             default:
-                views = getEditableViewsFromJson(context, jsonObject, listener, bundle,resolver);
+                views = getEditableViewsFromJson(context, jsonObject, listener, bundle, resolver);
         }
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
+    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
         List<View> views = new ArrayList<>(1);
-        views.add(getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")), jsonObject.getString("key"),
-                jsonObject.getString("type"), getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0),
-                FONT_BOLD_PATH));
+        views.add(
+            getTextViewWith(context, 16, bundle.resolveKey(jsonObject.getString("label")), jsonObject.getString("key"),
+                jsonObject.getString("type"), getLayoutParams(MATCH_PARENT, WRAP_CONTENT, 0, 0, 0, 0), FONT_BOLD_PATH));
 
         String orientationStr = (String) jsonObject.get("orientation");
         boolean horizontal = H_ORIENTATION_VALUE.equals(orientationStr);
@@ -64,21 +73,21 @@ public class RadioButtonFactory implements FormWidgetFactory {
 
         JSONArray options = null;
         String valuesExpression = getValuesAsJsonExpression(jsonObject, resolver);
-        if (valuesExpression!=null) {
+        if (valuesExpression != null) {
             JSONObject currentValues = getCurrentValues(context);
-            options = resolver.resolveAsArray(valuesExpression,currentValues);
+            options = resolver.resolveAsArray(valuesExpression, currentValues);
         } else {
             options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
         }
 
         int optionsLength = options.length();
-        if(optionsLength > 0) {
+        if (optionsLength > 0) {
             RadioGroup rg = new RadioGroup(context);
             rg.setOrientation(layoutOrientation);
             for (int i = 0; i < optionsLength; i++) {
                 JSONObject item = options.getJSONObject(i);
                 RadioButton radioButton = (RadioButton) LayoutInflater.from(context).inflate(R.layout.item_radiobutton,
-                        null);
+                    null);
                 radioButton.setId(i);
                 radioButton.setText(bundle.resolveKey(item.getString("text")));
                 radioButton.setTag(R.id.key, jsonObject.getString("key"));
@@ -88,12 +97,12 @@ public class RadioButtonFactory implements FormWidgetFactory {
                 radioButton.setTextSize(16);
                 radioButton.setTypeface(Typeface.createFromAsset(context.getAssets(), FONT_REGULAR_PATH));
                 radioButton.setOnCheckedChangeListener(listener);
-                if (!TextUtils.isEmpty(jsonObject.optString("value"))
-                        && jsonObject.optString("value").equals(item.getString("key"))) {
+                if (!TextUtils.isEmpty(jsonObject.optString("value")) && jsonObject.optString("value").equals(
+                    item.getString("key"))) {
                     radioButton.setChecked(true);
                 }
-                radioButton.setLayoutParams(getLayoutParams(layoutWidth, WRAP_CONTENT, 0, 0, 0, (int) context
-                        .getResources().getDimension(R.dimen.extra_bottom_margin)));
+                radioButton.setLayoutParams(getLayoutParams(layoutWidth, WRAP_CONTENT, 0, 0, 0,
+                    (int) context.getResources().getDimension(R.dimen.extra_bottom_margin)));
                 rg.addView(radioButton);
             }
             views.add(rg);
@@ -115,16 +124,17 @@ public class RadioButtonFactory implements FormWidgetFactory {
         if (context instanceof JsonApi) {
             String currentJsonState = ((JsonApi) context).currentJsonState();
             JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues =  JsonFormUtils.extractDataFromForm(currentJsonObject,false);
+            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
         }
         return currentValues;
     }
 
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)  throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
-        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(R.layout.item_edit_text,
+            null);
         editText.setId(ViewUtil.generateViewId());
         final String label = bundle.resolveKey(jsonObject.getString("label"));
         editText.setHint(label);
@@ -141,7 +151,7 @@ public class RadioButtonFactory implements FormWidgetFactory {
 
     private String resolveValueText(String value, JSONObject jsonObject, JsonFormBundle bundle) throws JSONException {
         String valueText = "";
-        if (value != null && !"".equals(value)){
+        if (value != null && !"".equals(value)) {
             JSONArray options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
             for (int i = 0; i < options.length(); i++) {
                 JSONObject item = options.getJSONObject(i);

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/SeparatorFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/SeparatorFactory.java
@@ -2,9 +2,7 @@ package com.vijay.jsonwizard.widgets;
 
 import android.content.Context;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 
 import com.vijay.jsonwizard.R;
 import com.vijay.jsonwizard.demo.resources.ResourceResolver;
@@ -26,12 +24,15 @@ import java.util.List;
 public class SeparatorFactory implements FormWidgetFactory {
 
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = new ArrayList<>(1);
         View v = new View(context);
-        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-        layoutParams.setMargins(0,10,0,10);
-        layoutParams.height=2;
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT);
+        layoutParams.setMargins(0, 10, 0, 10);
+        layoutParams.height = 2;
         v.setBackgroundColor(context.getResources().getColor(R.color.primary));
 
         v.setLayoutParams(layoutParams);

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/SpinnerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/SpinnerFactory.java
@@ -1,11 +1,12 @@
 package com.vijay.jsonwizard.widgets;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ArrayAdapter;
+
+import androidx.annotation.Nullable;
 
 import com.rengwuxian.materialedittext.MaterialEditText;
 import com.rey.material.util.ViewUtil;
@@ -20,36 +21,53 @@ import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
 
-import java.util.Arrays;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import fr.ganfra.materialspinner.MaterialSpinner;
-import org.json.JSONTokener;
 
 /**
  * Created by nipun on 30/05/15.
  */
 public class SpinnerFactory implements FormWidgetFactory {
 
+    public static ValidationStatus validate(MaterialSpinner spinner) {
+        if (!(spinner.getTag(R.id.v_required) instanceof String) || !(spinner.getTag(R.id.error) instanceof String)) {
+            return new ValidationStatus(true, null);
+        }
+        Boolean isRequired = Boolean.valueOf((String) spinner.getTag(R.id.v_required));
+        if (!isRequired) {
+            return new ValidationStatus(true, null);
+        }
+        int selectedItemPosition = spinner.getSelectedItemPosition();
+        if (selectedItemPosition > 0) {
+            return new ValidationStatus(true, null);
+        }
+        return new ValidationStatus(false, (String) spinner.getTag(R.id.error));
+    }
+
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = null;
-        switch (visualizationMode){
-            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :
+        switch (visualizationMode) {
+            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
                 views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
                 break;
             default:
-                views = getEditableViewsFromJson(context, jsonObject, listener, bundle,resolver);
+                views = getEditableViewsFromJson(context, jsonObject, listener, bundle, resolver);
         }
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
+    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
         List<View> views = new ArrayList<>(1);
         MaterialSpinner spinner = (MaterialSpinner) LayoutInflater.from(context).inflate(R.layout.item_spinner, null);
 
@@ -87,7 +105,7 @@ public class SpinnerFactory implements FormWidgetFactory {
             valuesJson = jsonObject.optJSONArray("values");
         } else {
             JSONObject currentValues = getCurrentValues(context);
-            valuesJson = resolver.resolveAsArray(valuesExpression,currentValues);
+            valuesJson = resolver.resolveAsArray(valuesExpression, currentValues);
         }
 
         String[] values = getValues(valuesJson);
@@ -113,9 +131,9 @@ public class SpinnerFactory implements FormWidgetFactory {
     private JSONObject getCurrentValues(Context context) throws JSONException {
         JSONObject currentValues = null;
         if (context instanceof JsonApi) {
-           String currentJsonState = ((JsonApi) context).currentJsonState();
-           JSONObject currentJsonObject = new JSONObject(currentJsonState);
-           currentValues =  JsonFormUtils.extractDataFromForm(currentJsonObject,false);
+            String currentJsonState = ((JsonApi) context).currentJsonState();
+            JSONObject currentJsonObject = new JSONObject(currentJsonState);
+            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
         }
         return currentValues;
     }
@@ -132,13 +150,13 @@ public class SpinnerFactory implements FormWidgetFactory {
         return values;
     }
 
-    private int getSelectedIdx(String[] values, String valueToSelect ) {
+    private int getSelectedIdx(String[] values, String valueToSelect) {
         int indexToSelect = -1;
         if (values != null && values.length > 0) {
             for (int i = 0; i < values.length; i++) {
-                 if (valueToSelect.equals(values[i])) {
-                     indexToSelect = i;
-                     break;
+                if (valueToSelect.equals(values[i])) {
+                    indexToSelect = i;
+                    break;
                 }
             }
         }
@@ -146,17 +164,18 @@ public class SpinnerFactory implements FormWidgetFactory {
     }
 
     private String getValuesAsJsonExpression(JSONObject jsonObject, JsonExpressionResolver resolver) {
-            String valuesExpression = jsonObject.optString("values");
-            if (resolver.isValidExpression(valuesExpression)) {
-                return valuesExpression;
-            }
-            return null;
+        String valuesExpression = jsonObject.optString("values");
+        if (resolver.isValidExpression(valuesExpression)) {
+            return valuesExpression;
+        }
+        return null;
     }
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle) throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
-        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+        MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(R.layout.item_edit_text,
+            null);
         editText.setId(ViewUtil.generateViewId());
         final String hint = jsonObject.getString("hint");
         editText.setHint(hint);
@@ -168,20 +187,5 @@ public class SpinnerFactory implements FormWidgetFactory {
         editText.setEnabled(false);
         views.add(editText);
         return views;
-    }
-
-    public static ValidationStatus validate(MaterialSpinner spinner) {
-        if (!(spinner.getTag(R.id.v_required) instanceof String) || !(spinner.getTag(R.id.error) instanceof String)) {
-            return new ValidationStatus(true, null);
-        }
-        Boolean isRequired = Boolean.valueOf((String) spinner.getTag(R.id.v_required));
-        if (!isRequired) {
-            return new ValidationStatus(true, null);
-        }
-        int selectedItemPosition = spinner.getSelectedItemPosition();
-        if(selectedItemPosition > 0) {
-            return new ValidationStatus(true, null);
-        }
-        return new ValidationStatus(false, (String) spinner.getTag(R.id.error));
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/TimePickerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/TimePickerFactory.java
@@ -35,11 +35,21 @@ public class TimePickerFactory implements FormWidgetFactory {
 
     private static final String TAG = "TimePickerFactory";
 
+    public static ValidationStatus validate(MaterialEditText editText) {
+        boolean validate = editText.validate();
+        if (!validate) {
+            return new ValidationStatus(false, editText.getError().toString());
+        }
+        return new ValidationStatus(true, null);
+    }
+
     @Override
-    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener, JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver, int visualizationMode) throws JSONException {
+    public List<View> getViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
+        JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver,
+        int visualizationMode) throws JSONException {
         List<View> views = null;
-        switch (visualizationMode){
-            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY :
+        switch (visualizationMode) {
+            case JsonFormConstants.VISUALIZATION_MODE_READ_ONLY:
                 views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
                 break;
             default:
@@ -48,10 +58,11 @@ public class TimePickerFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle) throws JSONException {
+    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
         final MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+            R.layout.item_edit_text, null);
         final String hint = bundle.resolveKey(jsonObject.getString("hint"));
 
         editText.setHint(hint);
@@ -69,7 +80,7 @@ public class TimePickerFactory implements FormWidgetFactory {
                 Date date = DateUtils.parseJSONDate(value);
                 SimpleDateFormat dateFormatter = new SimpleDateFormat(widgetPattern);
                 editText.setText(dateFormatter.format(date));
-            }catch (IllegalArgumentException e){
+            } catch (IllegalArgumentException e) {
                 Log.e(TAG, "Error parsing " + value + ": " + e.getMessage());
             }
         }
@@ -83,10 +94,11 @@ public class TimePickerFactory implements FormWidgetFactory {
         return views;
     }
 
-    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle) throws JSONException {
+    private List<View> getReadOnlyViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle)
+        throws JSONException {
         List<View> views = new ArrayList<>(1);
         final MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
-                R.layout.item_edit_text, null);
+            R.layout.item_edit_text, null);
         final String hint = bundle.resolveKey(jsonObject.getString("hint"));
 
         editText.setHint(hint);
@@ -103,7 +115,7 @@ public class TimePickerFactory implements FormWidgetFactory {
                 Date date = DateUtils.parseJSONDate(value);
                 SimpleDateFormat widgetDateFormat = new SimpleDateFormat(widgetPattern);
                 editText.setText(widgetDateFormat.format(date));
-            }catch (IllegalArgumentException e){
+            } catch (IllegalArgumentException e) {
                 Log.e(TAG, "Error parsing " + value + ": " + e.getMessage());
             }
         }
@@ -113,26 +125,18 @@ public class TimePickerFactory implements FormWidgetFactory {
         return views;
     }
 
-    public static ValidationStatus validate(MaterialEditText editText) {
-        boolean validate = editText.validate();
-        if(!validate) {
-            return new ValidationStatus(false, editText.getError().toString());
-        }
-        return new ValidationStatus(true, null);
-    }
-
     private class TimePickerListener implements View.OnFocusChangeListener, View.OnClickListener {
 
         private Dialog d;
         private MaterialEditText timeText;
 
-        public TimePickerListener(MaterialEditText editText){
+        public TimePickerListener(MaterialEditText editText) {
             this.timeText = editText;
         }
 
         @Override
         public void onFocusChange(View view, boolean focus) {
-            if(focus){
+            if (focus) {
                 openTimePicker(view);
             }
         }
@@ -143,11 +147,11 @@ public class TimePickerFactory implements FormWidgetFactory {
         }
 
         private void openTimePicker(View view) {
-            int hour=0;
-            int minute=0;
+            int hour = 0;
+            int minute = 0;
             String timeStr = timeText.getText().toString();
             String pattern = (String) timeText.getTag(R.id.v_pattern);
-            if(timeStr != null && !"".equals(timeStr)){
+            if (timeStr != null && !"".equals(timeStr)) {
                 try {
                     SimpleDateFormat dateFormatter = new SimpleDateFormat(pattern);
                     Calendar c = Calendar.getInstance();
@@ -155,24 +159,24 @@ public class TimePickerFactory implements FormWidgetFactory {
                     hour = c.get(Calendar.HOUR_OF_DAY);
                     minute = c.get(Calendar.MINUTE);
 
-                } catch (ParseException e){
+                } catch (ParseException e) {
                     Log.e(TAG, "Error parsing " + timeStr + ": " + e.getMessage());
                 }
-            }else{
+            } else {
                 final Calendar c = Calendar.getInstance();
                 hour = c.get(Calendar.HOUR_OF_DAY);
                 minute = c.get(Calendar.MINUTE);
             }
 
-            TimePickerDialog.Builder builder = new TimePickerDialog.Builder(hour,minute);
+            TimePickerDialog.Builder builder = new TimePickerDialog.Builder(hour, minute);
 
             d = builder.build(view.getContext());
 
             d.positiveActionClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    int selectedHour=((TimePickerDialog)d).getHour();
-                    int selectedMinute=((TimePickerDialog)d).getMinute();
+                    int selectedHour = ((TimePickerDialog) d).getHour();
+                    int selectedMinute = ((TimePickerDialog) d).getMinute();
                     timeText.setText(String.format("%02d:%02d", selectedHour, selectedMinute));
                     d.hide();
                 }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/WidgetFactoryRegistry.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/WidgetFactoryRegistry.java
@@ -1,10 +1,10 @@
 package com.vijay.jsonwizard.widgets;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by jurkiri on 23/11/17.
@@ -14,7 +14,7 @@ public class WidgetFactoryRegistry {
 
     private static final Map<String, FormWidgetFactory> map = new HashMap<>();
 
-    static{
+    static {
         map.put(JsonFormConstants.EDIT_TEXT, new EditTextFactory());
         map.put(JsonFormConstants.LABEL, new LabelFactory());
         map.put(JsonFormConstants.CHECK_BOX, new CheckBoxFactory());
@@ -27,6 +27,7 @@ public class WidgetFactoryRegistry {
         map.put(JsonFormConstants.SEPARATOR, new SeparatorFactory());
         map.put(JsonFormConstants.CAROUSEL, new CarouselFactory());
         map.put(JsonFormConstants.EXTENDED_LABEL, new ExtendedLabelFactory());
+        map.put(JsonFormConstants.BARCODE_TEXT, new BarcodeTextFactory());
     }
 
     public static FormWidgetFactory getWidgetFactory(String type) {

--- a/library/src/main/res/anim/enter_from_left.xml
+++ b/library/src/main/res/anim/enter_from_left.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shareInterpolator="false">
+     android:shareInterpolator="false">
     <translate
+        android:duration="@integer/navigationAnimTime"
         android:fromXDelta="-100%"
-        android:toXDelta="0"
         android:interpolator="@android:anim/decelerate_interpolator"
-        android:duration="@integer/navigationAnimTime" />
+        android:toXDelta="0"/>
 </set>

--- a/library/src/main/res/anim/enter_from_right.xml
+++ b/library/src/main/res/anim/enter_from_right.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fromXDelta="100%"
-    android:toXDelta="0"
-    android:interpolator="@android:anim/decelerate_interpolator"
-    android:duration="@integer/navigationAnimTime" />
+           android:duration="@integer/navigationAnimTime"
+           android:fromXDelta="100%"
+           android:interpolator="@android:anim/decelerate_interpolator"
+           android:toXDelta="0"/>

--- a/library/src/main/res/anim/exit_to_left.xml
+++ b/library/src/main/res/anim/exit_to_left.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shareInterpolator="false">
+     android:shareInterpolator="false">
     <translate
+        android:duration="@integer/navigationAnimTime"
         android:fromXDelta="0"
-        android:toXDelta="-100%"
         android:interpolator="@android:anim/decelerate_interpolator"
-        android:duration="@integer/navigationAnimTime" />
+        android:toXDelta="-100%"/>
     <!--<alpha-->
-        <!--android:fromAlpha="0.8"-->
-        <!--android:toAlpha="0.0"-->
-        <!--android:interpolator="@android:anim/accelerate_interpolator"-->
-        <!--android:duration="@integer/navigationAnimTime" />-->
+    <!--android:fromAlpha="0.8"-->
+    <!--android:toAlpha="0.0"-->
+    <!--android:interpolator="@android:anim/accelerate_interpolator"-->
+    <!--android:duration="@integer/navigationAnimTime" />-->
 </set>

--- a/library/src/main/res/anim/exit_to_right.xml
+++ b/library/src/main/res/anim/exit_to_right.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fromXDelta="0"
-    android:toXDelta="100%"
-    android:interpolator="@android:anim/decelerate_interpolator"
-    android:duration="@integer/navigationAnimTime" />
+           android:duration="@integer/navigationAnimTime"
+           android:fromXDelta="0"
+           android:interpolator="@android:anim/decelerate_interpolator"
+           android:toXDelta="100%"/>

--- a/library/src/main/res/anim/pop_enter_from_left.xml
+++ b/library/src/main/res/anim/pop_enter_from_left.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shareInterpolator="false">
+     android:shareInterpolator="false">
     <translate
+        android:duration="@integer/navigationAnimTime"
         android:fromXDelta="-100%"
-        android:toXDelta="0"
         android:interpolator="@android:anim/decelerate_interpolator"
-        android:duration="@integer/navigationAnimTime" />
+        android:toXDelta="0"/>
     <alpha
+        android:duration="@integer/navigationAnimTime"
         android:fromAlpha="0.0"
-        android:toAlpha="0.8"
         android:interpolator="@android:anim/accelerate_interpolator"
-        android:duration="@integer/navigationAnimTime" />
+        android:toAlpha="0.8"/>
 </set>

--- a/library/src/main/res/anim/pop_exit_to_right.xml
+++ b/library/src/main/res/anim/pop_exit_to_right.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fromXDelta="0"
-    android:toXDelta="100%"
-    android:interpolator="@android:anim/decelerate_interpolator"
-    android:duration="@integer/navigationAnimTime" />
+           android:duration="@integer/navigationAnimTime"
+           android:fromXDelta="0"
+           android:interpolator="@android:anim/decelerate_interpolator"
+           android:toXDelta="100%"/>

--- a/library/src/main/res/drawable/ic_switch_camera_white.xml
+++ b/library/src/main/res/drawable/ic_switch_camera_white.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp"
+        android:height="24dp" android:tint="#FFFFFF"
+        android:viewportWidth="24.0" android:viewportHeight="24.0">
+    <path android:fillColor="#FF000000"
+          android:pathData="M20,4h-3.17L15,2L9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM15,15.5L15,13L9,13v2.5L5.5,12 9,8.5L9,11h6L15,8.5l3.5,3.5 -3.5,3.5z"/>
+</vector>

--- a/library/src/main/res/drawable/textview_border.xml
+++ b/library/src/main/res/drawable/textview_border.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="rectangle">
-  <stroke
-    android:color="@color/primary_light"
-    android:width="1dp"/>
+       android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="@color/primary_light"/>
 </shape>

--- a/library/src/main/res/layout/activity_json_form.xml
+++ b/library/src/main/res/layout/activity_json_form.xml
@@ -1,23 +1,22 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/tb_top"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:background="?attr/colorPrimary"
         android:minHeight="?attr/actionBarSize"
-        />
+    />
 
     <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
                  android:id="@+id/container"
-                 android:layout_below="@+id/tb_top"
                  android:layout_width="match_parent"
                  android:layout_height="match_parent"
-        />
+                 android:layout_below="@+id/tb_top"
+    />
 </RelativeLayout>

--- a/library/src/main/res/layout/activity_live_preview.xml
+++ b/library/src/main/res/layout/activity_live_preview.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fireTopLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#000"
+    android:keepScreenOn="true">
+
+    <com.vijay.jsonwizard.barcode.common.CameraSourcePreview
+        android:id="@+id/firePreview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.vijay.jsonwizard.barcode.common.GraphicOverlay
+            android:id="@+id/fireFaceOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+    </com.vijay.jsonwizard.barcode.common.CameraSourcePreview>
+
+    <LinearLayout
+        android:id="@+id/buttonPanel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_margin="10dp"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center">
+
+            <ToggleButton
+                android:id="@+id/facingSwitch"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_centerHorizontal="true"
+                android:background="@layout/toggle_style"
+                android:checked="false"
+                android:textOff=""
+                android:textOn=""/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/selectedCode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:textColor="#FFF"
+                android:textSize="20dp"/>
+
+            <Button
+                android:id="@+id/submit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:enabled="false"
+                android:text="@string/save"/>
+
+        </LinearLayout>
+
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/library/src/main/res/layout/fragment_json_wizard.xml
+++ b/library/src/main/res/layout/fragment_json_wizard.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            android:orientation="vertical"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                  android:orientation="vertical"
                   android:id="@+id/main_layout"
-                  android:layout_marginTop="8dp"
-                  android:layout_marginLeft="@dimen/default_left_margin"
-                  android:layout_marginRight="@dimen/default_right_margin"
                   android:layout_width="match_parent"
-                  android:layout_height="match_parent">
+                  android:layout_height="match_parent"
+                  android:layout_marginLeft="@dimen/default_left_margin"
+                  android:layout_marginTop="8dp"
+                  android:layout_marginRight="@dimen/default_right_margin"
+                  android:orientation="vertical">
 
     </LinearLayout>
 </ScrollView>

--- a/library/src/main/res/layout/item_barcode_edit_text.xml
+++ b/library/src/main/res/layout/item_barcode_edit_text.xml
@@ -1,0 +1,32 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <com.rengwuxian.materialedittext.MaterialEditText
+        android:id="@+id/edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textSize="@dimen/default_text_size"
+        app:met_floatingLabel="highlight"
+        app:met_floatingLabelText=""
+        app:met_primaryColor="?colorAccent"
+        app:met_singleLineEllipsis="true"
+        app:met_typeface="font/Roboto-Regular.ttf"/>
+
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="0"
+        android:clickable="true"
+        android:paddingLeft="10dp"
+        android:src="@mipmap/barcode_scan_icon"/>
+
+
+</LinearLayout>

--- a/library/src/main/res/layout/item_button.xml
+++ b/library/src/main/res/layout/item_button.xml
@@ -2,6 +2,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textAppearance="@style/Base.TextAppearance.AppCompat.Button"
     android:text=""
-    />
+    android:textAppearance="@style/Base.TextAppearance.AppCompat.Button"
+/>

--- a/library/src/main/res/layout/item_carousel_element.xml
+++ b/library/src/main/res/layout/item_carousel_element.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
+<androidx.appcompat.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="200dp"
     android:layout_height="260dp"
-    android:layout_margin="4dp"
-    android:layout_gravity="center">
+    android:layout_gravity="center"
+    android:layout_margin="4dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -15,8 +15,8 @@
             android:id="@+id/name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAllCaps="true"
             android:gravity="center"
+            android:textAllCaps="true"
             android:textColor="@android:color/black"
             android:textSize="15sp"
             android:textStyle="bold"/>
@@ -35,4 +35,4 @@
 
     </LinearLayout>
 
-</android.support.v7.widget.CardView>
+</androidx.appcompat.widget.CardView>

--- a/library/src/main/res/layout/item_carousel_popup.xml
+++ b/library/src/main/res/layout/item_carousel_popup.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
     <ImageView
         android:id="@+id/image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scaleType="fitCenter"
         android:layout_centerInParent="true"
-        android:adjustViewBounds="true" />
+        android:adjustViewBounds="true"
+        android:scaleType="fitCenter"/>
 
 </RelativeLayout>

--- a/library/src/main/res/layout/item_checkbox.xml
+++ b/library/src/main/res/layout/item_checkbox.xml
@@ -1,7 +1,7 @@
 <com.vijay.jsonwizard.customviews.CheckBox
+    xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/Material.Drawable.CheckBox"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:android="http://schemas.android.com/apk/res/android"
     android:focusable="true"
-    />
+/>

--- a/library/src/main/res/layout/item_edit_text.xml
+++ b/library/src/main/res/layout/item_edit_text.xml
@@ -4,9 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textSize="@dimen/default_text_size"
-    app:met_typeface="font/Roboto-Regular.ttf"
     app:met_floatingLabel="highlight"
     app:met_floatingLabelText=""
     app:met_primaryColor="?colorAccent"
     app:met_singleLineEllipsis="true"
-    />
+    app:met_typeface="font/Roboto-Regular.ttf"
+/>

--- a/library/src/main/res/layout/item_extended_label.xml
+++ b/library/src/main/res/layout/item_extended_label.xml
@@ -3,10 +3,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_gravity="center"
     android:layout_marginTop="@dimen/extra_bottom_margin"
     android:layout_marginBottom="32dp"
-    android:layout_gravity="center"
-    android:padding="10dp"
     android:background="@drawable/textview_border"
-    android:textAppearance="@android:style/TextAppearance.Small" />
+    android:padding="10dp"
+    android:textAppearance="@android:style/TextAppearance.Small"/>
 

--- a/library/src/main/res/layout/item_radiobutton.xml
+++ b/library/src/main/res/layout/item_radiobutton.xml
@@ -1,7 +1,7 @@
 <com.vijay.jsonwizard.customviews.RadioButton
+    xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/Material.Drawable.RadioButton"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:android="http://schemas.android.com/apk/res/android"
     android:focusable="true"
-    />
+/>

--- a/library/src/main/res/layout/item_spinner.xml
+++ b/library/src/main/res/layout/item_spinner.xml
@@ -3,10 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    app:ms_multiline="false"
-    app:ms_typeface="font/Roboto-Regular.ttf"
+    app:ms_alignLabels="true"
     app:ms_arrowColor="?colorPrimaryDark"
     app:ms_arrowSize="16dp"
-    app:ms_alignLabels="true"
     app:ms_floatingLabelColor="@color/secondary_text"
- />
+    app:ms_multiline="false"
+    app:ms_typeface="font/Roboto-Regular.ttf"
+/>

--- a/library/src/main/res/layout/toggle_style.xml
+++ b/library/src/main/res/layout/toggle_style.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_switch_camera_white" android:state_checked="true"/>
+    <item android:drawable="@drawable/ic_switch_camera_white" android:state_checked="false"/>
+</selector>

--- a/library/src/main/res/menu/menu_toolbar.xml
+++ b/library/src/main/res/menu/menu_toolbar.xml
@@ -1,17 +1,17 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:tools="http://schemas.android.com/tools"
       xmlns:app="http://schemas.android.com/apk/res-auto"
+      xmlns:tools="http://schemas.android.com/tools"
       tools:context=".MainActivity">
     <item
         android:id="@+id/action_next"
-        android:title="@string/next"
         android:orderInCategory="100"
+        android:title="@string/next"
         app:showAsAction="always"
-        />
+    />
     <item
         android:id="@+id/action_save"
-        android:title="@string/save"
         android:orderInCategory="100"
+        android:title="@string/save"
         app:showAsAction="always"
-        />
+    />
 </menu>

--- a/library/src/main/res/values-es/strings.xml
+++ b/library/src/main/res/values-es/strings.xml
@@ -5,4 +5,5 @@
     <string name="save">Guardar</string>
     <string name="summary">Resumen</string>
     <string name="image_picker">Seleccionar imagen</string>
+    <string name="mlkit_not_found">Módulo MLkit no encontrado. Espere a que se complete la descarga</string>
 </resources>

--- a/library/src/main/res/values-fr/strings.xml
+++ b/library/src/main/res/values-fr/strings.xml
@@ -5,4 +5,5 @@
     <string name="save">Enregistrer</string>
     <string name="summary">Récapitulatif</string>
     <string name="image_picker">Sélectionner l\'image</string>
+    <string name="mlkit_not_found">Módulo MLkit no encontrado. Espere a que se complete la descarga</string>
 </resources>

--- a/library/src/main/res/values/ids.xml
+++ b/library/src/main/res/values/ids.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="id" name="key"/>
-    <item type="id" name="type"/>
-    <item type="id" name="childKey"/>
-    <item type="id" name="imagePath"/>
-    <item type="id" name="required"/>
-    <item type="id" name="v_required"/>
-    <item type="id" name="error"/>
-    <item type="id" name="v_pattern"/>
-    <item type="id" name="minDate"/>
-    <item type="id" name="maxDate"/>
+    <item name="key" type="id"/>
+    <item name="type" type="id"/>
+    <item name="childKey" type="id"/>
+    <item name="imagePath" type="id"/>
+    <item name="required" type="id"/>
+    <item name="v_required" type="id"/>
+    <item name="error" type="id"/>
+    <item name="v_pattern" type="id"/>
+    <item name="minDate" type="id"/>
+    <item name="maxDate" type="id"/>
 
     <!-- signle, multiple -->
-    <item type="id" name="valueType"/>
+    <item name="valueType" type="id"/>
 </resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="library_name">jsonwizard</string>
     <string name="next">Next</string>
     <string name="save">Save</string>
-    <string name="summary">Resumen</string>
+    <string name="summary">Summary</string>
     <string name="image_picker">Choose image</string>
+    <string name="mlkit_not_found">Module MLkit manquant. Attendez que le téléchargement soit terminé</string>
 </resources>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,30 +1,33 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
-        applicationId "com.vijay.jsonwizard.demo"
+        applicationId "com.orona.forms.des"
         minSdkVersion 21
         targetSdkVersion 26
         versionCode 2
         versionName "1.2.1"
     }
     buildTypes {
+        debug {
+            minifyEnabled false
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {
-         abortOnError false
+        abortOnError false
     }
 }
-repositories {
-    maven {url "https://clojars.org/repo/"}
-}
+
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':library')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':library')
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,30 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.vijay.jsonwizard.demo" >
+    package="com.vijay.jsonwizard.demo">
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/library_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme">
+
         <activity
             android:name=".activities.MainActivity"
-            android:label="@string/library_name"
-            android:configChanges="orientation|screenSize|keyboardHidden">
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:label="@string/library_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity
             android:name="com.vijay.jsonwizard.activities.JsonFormActivity"
-            android:label="@string/library_name"
-            android:configChanges="orientation|screenSize|keyboardHidden"/>
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:label="@string/library_name" />
     </application>
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-feature android:name="android.hardware.camera" android:required="true" />
 </manifest>

--- a/sample/src/main/java/com/vijay/jsonwizard/demo/activities/MainActivity.java
+++ b/sample/src/main/java/com/vijay/jsonwizard/demo/activities/MainActivity.java
@@ -1,8 +1,13 @@
 package com.vijay.jsonwizard.demo.activities;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONTokener;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.vijay.jsonwizard.activities.JsonFormActivity;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
@@ -10,13 +15,9 @@ import com.vijay.jsonwizard.demo.R;
 import com.vijay.jsonwizard.demo.utils.CommonUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.os.Bundle;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
-import android.view.View;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 
 /**
  * Created by vijay on 5/16/15.
@@ -26,8 +27,18 @@ public class MainActivity extends AppCompatActivity {
     private static final int REQUEST_CODE_GET_JSON = 1;
 
     private static final String TAG = "MainActivity";
-    private static final String DATA_JSON_PATH = "form.json";
+    private static final String DATA_JSON_PATH = "data.json";
     private static final String COMPLETE_JSON_PATH = "complete.json";
+
+    private static JSONObject extractDataFromForm(String form) {
+        try {
+            return JsonFormUtils.extractDataFromForm(
+                (JSONObject) new JSONTokener(form).nextValue());
+        } catch (JSONException e) {
+            Log.e(TAG, "Error parsing JSON document", e);
+        }
+        return null;
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -37,13 +48,15 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(MainActivity.this, JsonFormActivity.class);
-                String json = CommonUtils
-                        .loadJSONFromAsset(getApplicationContext(), DATA_JSON_PATH);
+                String json = CommonUtils.loadJSONFromAsset(getApplicationContext(),
+                    DATA_JSON_PATH);
                 intent.putExtra("json", json);
                 intent.putExtra("resolver",
-                        "com.vijay.jsonwizard.demo.expressions.AssetsContentResolver");
-                //intent.putExtra(JsonFormConstants.ORIENTATION_EXTRA, JsonFormConstants.ORIENTATION_LANDSCAPE);
-                //intent.putExtra(JsonFormConstants.INPUT_METHOD_EXTRA, JsonFormConstants.INPUT_METHOD_HIDDEN);
+                    "com.vijay.jsonwizard.demo.expressions.AssetsContentResolver");
+                //intent.putExtra(JsonFormConstants.ORIENTATION_EXTRA, JsonFormConstants
+                // .ORIENTATION_LANDSCAPE);
+                //intent.putExtra(JsonFormConstants.INPUT_METHOD_EXTRA, JsonFormConstants
+                // .INPUT_METHOD_HIDDEN);
                 startActivityForResult(intent, REQUEST_CODE_GET_JSON);
             }
         });
@@ -51,11 +64,11 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(MainActivity.this, JsonFormActivity.class);
-                String json = CommonUtils
-                        .loadJSONFromAsset(getApplicationContext(), COMPLETE_JSON_PATH);
+                String json = CommonUtils.loadJSONFromAsset(getApplicationContext(),
+                    COMPLETE_JSON_PATH);
                 intent.putExtra("json", json);
                 intent.putExtra(JsonFormConstants.VISUALIZATION_MODE_EXTRA,
-                        JsonFormConstants.VISUALIZATION_MODE_READ_ONLY);
+                    JsonFormConstants.VISUALIZATION_MODE_READ_ONLY);
                 startActivityForResult(intent, REQUEST_CODE_GET_JSON);
             }
         });
@@ -69,29 +82,18 @@ public class MainActivity extends AppCompatActivity {
             JSONObject result = extractDataFromForm(json);
             Log.d(TAG, result.toString());
         } else if (requestCode == REQUEST_CODE_GET_JSON
-                && resultCode == JsonFormConstants.RESULT_JSON_PARSE_ERROR) {
+            && resultCode == JsonFormConstants.RESULT_JSON_PARSE_ERROR) {
             AlertDialog alertDialog = new AlertDialog.Builder(MainActivity.this).create();
             alertDialog.setTitle("Error");
             alertDialog.setMessage((CharSequence) data.getData().toString());
             alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "OK",
-                    new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int which) {
-                            dialog.dismiss();
-                        }
-                    });
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                });
             alertDialog.show();
         }
         super.onActivityResult(requestCode, resultCode, data);
-    }
-
-
-    private static JSONObject extractDataFromForm(String form) {
-        try {
-            return JsonFormUtils
-                    .extractDataFromForm((JSONObject) new JSONTokener(form).nextValue());
-        } catch (JSONException e) {
-            Log.e(TAG, "Error parsing JSON document", e);
-        }
-        return null;
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
     <Button
         android:id="@+id/button_start"
-        android:text="@string/click_to_launch"
-        android:layout_centerInParent="true"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="@string/click_to_launch"/>
     <Button
         android:id="@+id/button_start_ro"
-        android:text="@string/click_to_launch_ro"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/button_start"
         android:layout_alignStart="@+id/button_start"
-        android:layout_alignEnd="@+id/button_start" />
+        android:layout_alignEnd="@+id/button_start"
+        android:text="@string/click_to_launch_ro"/>
 </RelativeLayout>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':library',':sample'
+include ':library', ':sample'


### PR DESCRIPTION
Main change:
-Added barcode_text. barcode_text is a widget based on edit_text that enables to input de text by scanning a barcode using Firebase MLKit API. Has the same properties and validations as edit_text.
Other changes:
-Migrated proyect to AndroidX
-Fixed save toast not showing