### PR TITLE
Support for step templates

### DIFF
--- a/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
+++ b/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
@@ -1,5 +1,6 @@
 package com.vijay.jsonwizard.activities;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.database.Cursor;
@@ -10,6 +11,7 @@ import android.util.Log;
 import android.view.Surface;
 import android.view.WindowManager;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
@@ -32,6 +34,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Iterator;
 import java.util.Locale;
 
 import static com.vijay.jsonwizard.constants.JsonFormConstants.MAX_PARCEL_SIZE;
@@ -193,7 +196,27 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
                 }
             }
         }
+
+        if (step.has("template_params")) {
+            JSONObject newParamsContainer = new JSONObject();
+            JsonExpressionResolver expressionResolver = getExpressionResolver();
+            JSONObject params = step.getJSONObject("template_params");
+            Iterator<String> it = params.keys();
+            JSONObject currentValues = getCurrentValues();
+            while (it.hasNext()) {
+                String key = it.next();
+
+                String value = expressionResolver.resolveAsString(params.getString(key), currentValues);
+                newParamsContainer.put(key, value);
+            }
+            newStep.put("template_params", newParamsContainer);
+        }
+
         return newStep;
+    }
+
+    private JSONObject getCurrentValues() throws JSONException {
+        return JsonFormUtils.extractDataFromForm(mJSONObject, false);
     }
 
     private void setOptionsValue(String name, JSONObject step, String parentKey, JSONObject target)

--- a/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
+++ b/library/src/main/java/com/vijay/jsonwizard/activities/JsonFormActivity.java
@@ -206,7 +206,10 @@ public class JsonFormActivity extends AppCompatActivity implements JsonApi {
             while (it.hasNext()) {
                 String key = it.next();
 
-                String value = expressionResolver.resolveAsString(params.getString(key), currentValues);
+                String value = params.getString(key);
+                if (expressionResolver.isValidExpression(value)) {
+                    value = expressionResolver.resolveAsString(params.getString(key), currentValues);
+                }
                 newParamsContainer.put(key, value);
             }
             newStep.put("template_params", newParamsContainer);

--- a/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
@@ -20,6 +20,7 @@ import java.util.EnumSet;
 import java.util.Set;
 
 public class JsonExpressionResolver {
+    private static final String TAG = "Resolver";
 
     static {
         Configuration.setDefaults(new Configuration.Defaults() {
@@ -87,36 +88,51 @@ public class JsonExpressionResolver {
     }
 
     public String resolveAsString(String expression, JSONObject instance) throws JSONException {
-        JSONArray array = resolveExpression(expression, instance);
-        if (array == null || array.length() == 0) {
-            return null;
+        try {
+            JSONArray array = resolveExpression(expression, instance);
+
+            if (array == null || array.length() == 0) {
+                return null;
+            }
+            if (array.isNull(0)) {
+                return null;
+            }
+            return array.getString(0);
+        } catch (PathNotFoundException e) {
+            Log.e(TAG, "Path not found: " + expression, e);
         }
-        if (array.isNull(0)) {
-            return null;
-        }
-        return array.getString(0);
+        return null;
     }
 
     public JSONArray resolveAsArray(String expression, JSONObject instance) {
-        JSONArray array = resolveExpression(expression, instance);
-        if (array == null || array.length() == 0) {
-            return null;
+        try {
+            JSONArray array = resolveExpression(expression, instance);
+            if (array == null || array.length() == 0) {
+                return null;
+            }
+            Object item = array.opt(0);
+            if (item instanceof JSONArray) {
+                return (JSONArray) item;
+            }
+            return array;
+        } catch (PathNotFoundException e) {
+            Log.e(TAG, "Path not found: " + expression, e);
         }
-        Object item = array.opt(0);
-        if (item instanceof JSONArray) {
-            return (JSONArray) item;
-        }
-        return array;
+        return null;
     }
 
     public JSONObject resolveAsObject(String expression, JSONObject instance) {
-        JSONArray array = resolveExpression(expression, instance);
-        if (array == null || array.length() == 0) {
-            return null;
-        }
-        Object item = array.opt(0);
-        if (item instanceof JSONObject) {
-            return (JSONObject) item;
+        try {
+            JSONArray array = resolveExpression(expression, instance);
+            if (array == null || array.length() == 0) {
+                return null;
+            }
+            Object item = array.opt(0);
+            if (item instanceof JSONObject) {
+                return (JSONObject) item;
+            }
+        } catch (PathNotFoundException e) {
+            Log.e(TAG, "Path not found: " + expression, e);
         }
         return null;
     }
@@ -131,14 +147,14 @@ public class JsonExpressionResolver {
             localContext = contentCache.get(externalReference);
             if (localContext == null) {
                 Log.w("ExpressionResolver",
-                    "resolveAsArray: external content " + externalReference + " can not be loaded");
+                        "resolveAsArray: external content " + externalReference + " can not be loaded");
                 return null;
             }
 
             localExpression = extractJsonExpression(expression);
             if (localExpression == null) {
                 Log.w("ExpressionResolver",
-                    "resolveAsArray: external content expression can not be extracted " + expression);
+                        "resolveAsArray: external content expression can not be extracted " + expression);
                 return null;
             }
         }
@@ -163,14 +179,14 @@ public class JsonExpressionResolver {
             localContext = contentCache.get(externalReference);
             if (localContext == null) {
                 Log.w("ExpressionResolver",
-                    "resolveAsArray: external content " + externalReference + " can not be loaded");
+                        "resolveAsArray: external content " + externalReference + " can not be loaded");
                 return false;
             }
 
             localExpression = extractJsonExpression(expression);
             if (localExpression == null) {
                 Log.w("ExpressionResolver",
-                    "resolveAsArray: external content expression can not be extracted " + expression);
+                        "resolveAsArray: external content expression can not be extracted " + expression);
                 return false;
             }
         }

--- a/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
+++ b/library/src/main/java/com/vijay/jsonwizard/expressions/JsonExpressionResolver.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
@@ -162,11 +163,15 @@ public class JsonExpressionResolver {
         if (instance != null) {
             localContext.put("$", "current-values", instance);
         }
-        JSONArray array = localContext.read(localExpression);
+        try {
+            JSONArray array = localContext.read(localExpression);
+            localContext.delete("current-values");
+            return array;
+        } catch (JsonPathException e) {
+            Log.e(TAG, "Error evaluation expression " + localExpression, e);
+        }
 
-        localContext.delete("current-values");
-
-        return array;
+        return null;
     }
 
     public boolean existsExpression(String expression, JSONObject instance) throws JSONException {

--- a/library/src/main/java/com/vijay/jsonwizard/utils/ExpressionResolverContextUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/ExpressionResolverContextUtils.java
@@ -1,0 +1,36 @@
+package com.vijay.jsonwizard.utils;
+
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
+import com.vijay.jsonwizard.interfaces.JsonApi;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class ExpressionResolverContextUtils {
+    private static final String TAG = "ExpContextUtils";
+
+    @Nullable
+    public static JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+        JSONObject currentValues = null;
+        if (context instanceof JsonApi) {
+            String currentJsonState = ((JsonApi) context).currentJsonState();
+            JSONObject currentJsonObject = new JSONObject(currentJsonState);
+            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
+
+            JSONObject step = currentJsonObject.getJSONObject(stepName);
+            if (step.has("template_params")) {
+                /*
+                  TODO: Optimize step retrieval. Following method rebuilds step from template.
+                  Can be optimized by giving access to the step definition built during fragment initialization
+                */
+                step = ((JsonApi) context).getStep(stepName);
+                JSONObject templateParams = step.getJSONObject("template_params");
+                currentValues.put("template_params", templateParams);
+            }
+        }
+        return currentValues;
+    }
+}

--- a/library/src/main/java/com/vijay/jsonwizard/utils/JsonFormUtils.java
+++ b/library/src/main/java/com/vijay/jsonwizard/utils/JsonFormUtils.java
@@ -68,6 +68,17 @@ public class JsonFormUtils {
         return null;
     }
 
+    public static JSONObject findFieldInJSON(JSONObject root, String key) throws JSONException {
+        JSONArray fields = root.getJSONArray("fields");
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = (JSONObject) fields.get(i);
+            if (field != null && field.has("key") && field.getString("key").equals(key)) {
+                return field;
+            }
+        }
+        return null;
+    }
+
     private static JSONObject findInJSON(JSONObject root, String key) throws JSONException {
         JSONArray fields = root.getJSONArray("fields");
         for (int i = 0; i < fields.length(); i++) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/BarcodeTextFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/BarcodeTextFactory.java
@@ -22,6 +22,7 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
 import com.vijay.jsonwizard.validators.edittext.MaxLengthValidator;
@@ -66,7 +67,7 @@ public class BarcodeTextFactory implements FormWidgetFactory {
         boolean readonly = false;
 
         if (resolver.isValidExpression(readonlyValue)) {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             readonly = resolver.existsExpression(readonlyValue, currentValues);
         } else {
             readonly = Boolean.TRUE.toString().equalsIgnoreCase(readonlyValue);
@@ -110,7 +111,7 @@ public class BarcodeTextFactory implements FormWidgetFactory {
             if (!TextUtils.isEmpty(requiredValue)) {
                 boolean required = false;
                 if (resolver.isValidExpression(requiredValue)) {
-                    JSONObject currentValues = getCurrentValues(context);
+                    JSONObject currentValues = getCurrentValues(context,stepName);
                     required = resolver.existsExpression(requiredValue, currentValues);
                 } else {
                     required = Boolean.TRUE.toString().equalsIgnoreCase(requiredValue);
@@ -227,13 +228,7 @@ public class BarcodeTextFactory implements FormWidgetFactory {
     }
 
     @Nullable
-    private JSONObject getCurrentValues(Context context) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-        }
-        return currentValues;
+    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+       return ExpressionResolverContextUtils.getCurrentValues(context, stepName);
     }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/CarouselFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/CarouselFactory.java
@@ -20,6 +20,7 @@ import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.CarouselAdapter;
 import com.vijay.jsonwizard.utils.CarouselItem;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
 import com.yarolegovich.discretescrollview.DSVOrientation;
@@ -66,12 +67,12 @@ public class CarouselFactory implements FormWidgetFactory {
                 views = getReadOnlyViewsFromJson(context, jsonObject);
                 break;
             default:
-                views = getEditableViewsFromJson(context, jsonObject, listener, bundle, resolver, resourceResolver);
+                views = getEditableViewsFromJson(stepName, context, jsonObject, listener, bundle, resolver, resourceResolver);
         }
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener,
+    private List<View> getEditableViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
         JsonFormBundle bundle, JsonExpressionResolver resolver, ResourceResolver resourceResolver)
         throws JSONException {
         List<View> views = new ArrayList<>(1);
@@ -107,7 +108,7 @@ public class CarouselFactory implements FormWidgetFactory {
         if (valuesExpression == null) {
             valuesJson = jsonObject.optJSONArray("values");
         } else {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             valuesJson = resolver.resolveAsArray(valuesExpression, currentValues);
         }
 
@@ -117,7 +118,7 @@ public class CarouselFactory implements FormWidgetFactory {
         if (imagesExpression == null) {
             imagesJson = jsonObject.optJSONArray("images");
         } else {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             imagesJson = resolver.resolveAsArray(imagesExpression, currentValues);
         }
 
@@ -174,14 +175,8 @@ public class CarouselFactory implements FormWidgetFactory {
     }
 
     @Nullable
-    private JSONObject getCurrentValues(Context context) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-        }
-        return currentValues;
+    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+        return ExpressionResolverContextUtils.getCurrentValues(context, stepName);
     }
 
     private String[] getValues(JSONArray valuesJson) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/EditTextFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/EditTextFactory.java
@@ -21,6 +21,7 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
 import com.vijay.jsonwizard.validators.edittext.MaxLengthValidator;
@@ -68,7 +69,7 @@ public class EditTextFactory implements FormWidgetFactory {
         boolean readonly = false;
 
         if (resolver.isValidExpression(readonlyValue)) {
-            JSONObject currentValues = getCurrentValues(context, stepName);
+            JSONObject currentValues = ExpressionResolverContextUtils.getCurrentValues(context, stepName);
             readonly = resolver.existsExpression(readonlyValue, currentValues);
         } else {
             readonly = Boolean.TRUE.toString().equalsIgnoreCase(readonlyValue);
@@ -92,7 +93,7 @@ public class EditTextFactory implements FormWidgetFactory {
 
         String value = jsonObject.optString("value");
         if (resolver.isValidExpression(value)) {
-            JSONObject currentValues = getCurrentValues(context, stepName);
+            JSONObject currentValues = ExpressionResolverContextUtils.getCurrentValues(context, stepName);
             value = resolver.resolveAsString(value, currentValues);
         }
         if (!TextUtils.isEmpty(value)) {
@@ -111,7 +112,7 @@ public class EditTextFactory implements FormWidgetFactory {
             if (!TextUtils.isEmpty(requiredValue)) {
                 boolean required = false;
                 if (resolver.isValidExpression(requiredValue)) {
-                    JSONObject currentValues = getCurrentValues(context, stepName);
+                    JSONObject currentValues = ExpressionResolverContextUtils.getCurrentValues(context, stepName);
                     required = resolver.existsExpression(requiredValue, currentValues);
                 } else {
                     required = Boolean.TRUE.toString().equalsIgnoreCase(requiredValue);
@@ -221,25 +222,4 @@ public class EditTextFactory implements FormWidgetFactory {
         return views;
     }
 
-    @Nullable
-    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-
-            JSONObject step = currentJsonObject.getJSONObject(stepName);
-            if (step.has("template_params")) {
-                /*
-                  TODO: Optimize step retrieval. Following method rebuilds step from template.
-                  Can be optimized by giving access to the step definition built during fragment initialization
-                */
-                step = ((JsonApi) context).getStep(stepName);
-                JSONObject templateParams = step.getJSONObject("template_params");
-                currentValues.put("template_params", templateParams);
-            }
-        }
-        return currentValues;
-    }
 }

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/ExtendedLabelFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/ExtendedLabelFactory.java
@@ -16,6 +16,7 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 
 import org.json.JSONArray;
@@ -59,7 +60,7 @@ public class ExtendedLabelFactory implements FormWidgetFactory {
         if (valuesExpression == null) {
             textValue = bundle.resolveKey(jsonObject.getString(TEXT_FIELD));
         } else {
-            currentValues = getCurrentValues(context);
+            currentValues = getCurrentValues(context, stepName);
             textValue = resolver.resolveAsString(valuesExpression, currentValues);
         }
 
@@ -67,7 +68,7 @@ public class ExtendedLabelFactory implements FormWidgetFactory {
         JSONArray params = jsonObject.optJSONArray(PARAMS_FIELD);
         if (params != null && params.length() > 0) {
             if (currentValues == null) {
-                currentValues = getCurrentValues(context);
+                currentValues = getCurrentValues(context, stepName);
             }
             for (int i = 0; i < params.length(); i++) {
                 String expression = params.getString(i);
@@ -90,14 +91,8 @@ public class ExtendedLabelFactory implements FormWidgetFactory {
     }
 
     @Nullable
-    private JSONObject getCurrentValues(Context context) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-        }
-        return currentValues;
+    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+        return ExpressionResolverContextUtils.getCurrentValues(context, stepName);
     }
 
     private String getValuesAsJsonExpression(JSONObject jsonObject, JsonExpressionResolver resolver) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/LabelFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/LabelFactory.java
@@ -24,6 +24,7 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 
 import org.json.JSONException;
@@ -66,7 +67,7 @@ public class LabelFactory implements FormWidgetFactory {
         if (valuesExpression == null) {
             textValue = bundle.resolveKey(jsonObject.getString(TEXT_FIELD));
         } else {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             textValue = resolver.resolveAsString(valuesExpression, currentValues);
         }
 
@@ -98,7 +99,7 @@ public class LabelFactory implements FormWidgetFactory {
         if (valuesExpression == null) {
             textValue = bundle.resolveKey(jsonObject.getString(TEXT_FIELD));
         } else {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             textValue = resolver.resolveAsString(valuesExpression, currentValues);
         }
 
@@ -110,14 +111,8 @@ public class LabelFactory implements FormWidgetFactory {
     }
 
     @Nullable
-    private JSONObject getCurrentValues(Context context) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-        }
-        return currentValues;
+    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+        return ExpressionResolverContextUtils.getCurrentValues(context, stepName);
     }
 
     private String getValuesAsJsonExpression(JSONObject jsonObject, JsonExpressionResolver resolver) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/RadioButtonFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/RadioButtonFactory.java
@@ -28,6 +28,7 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 
 import org.json.JSONArray;
@@ -54,12 +55,12 @@ public class RadioButtonFactory implements FormWidgetFactory {
                 views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
                 break;
             default:
-                views = getEditableViewsFromJson(context, jsonObject, listener, bundle, resolver);
+                views = getEditableViewsFromJson(stepName, context, jsonObject, listener, bundle, resolver);
         }
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, CommonListener listener,
+    private List<View> getEditableViewsFromJson(String stepName, Context context, JSONObject jsonObject, CommonListener listener,
         JsonFormBundle bundle, JsonExpressionResolver resolver) throws JSONException {
         List<View> views = new ArrayList<>(1);
         views.add(
@@ -74,7 +75,7 @@ public class RadioButtonFactory implements FormWidgetFactory {
         JSONArray options = null;
         String valuesExpression = getValuesAsJsonExpression(jsonObject, resolver);
         if (valuesExpression != null) {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             options = resolver.resolveAsArray(valuesExpression, currentValues);
         } else {
             options = jsonObject.getJSONArray(JsonFormConstants.OPTIONS_FIELD_NAME);
@@ -119,14 +120,8 @@ public class RadioButtonFactory implements FormWidgetFactory {
     }
 
     @Nullable
-    private JSONObject getCurrentValues(Context context) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-        }
-        return currentValues;
+    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+        return ExpressionResolverContextUtils.getCurrentValues(context, stepName);
     }
 
 

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/ResourceViewerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/ResourceViewerFactory.java
@@ -26,6 +26,7 @@ import com.vijay.jsonwizard.i18n.JsonFormBundle;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 
 import org.json.JSONException;
@@ -55,7 +56,7 @@ public class ResourceViewerFactory implements FormWidgetFactory {
         // Load json data
         String resource = jsonObject.getString("resource");
         if (resolver.isValidExpression(resource)) {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             resource = resolver.resolveAsString(resource, currentValues);
         }
 
@@ -69,7 +70,7 @@ public class ResourceViewerFactory implements FormWidgetFactory {
         String iconPath = bundle.resolveKey(jsonObject.optString("icon"));
 
         if (resolver.isValidExpression(labelText)) {
-            JSONObject currentValues = getCurrentValues(context);
+            JSONObject currentValues = getCurrentValues(context, stepName);
             labelText = resolver.resolveAsString(labelText, currentValues);
         } else {
             labelText = bundle.resolveKey(labelText);
@@ -90,7 +91,7 @@ public class ResourceViewerFactory implements FormWidgetFactory {
                 String expression = jsonObject.optString("config");
                 JSONObject config;
                 if (resolver.isValidExpression(expression)) {
-                    JSONObject currentValues = getCurrentValues(context);
+                    JSONObject currentValues = getCurrentValues(context, stepName);
                     config = resolver.resolveAsObject(expression, currentValues);
                 } else {
                     config = jsonObject.getJSONObject("config");
@@ -195,14 +196,8 @@ public class ResourceViewerFactory implements FormWidgetFactory {
     }
 
     @Nullable
-    private JSONObject getCurrentValues(Context context) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-        }
-        return currentValues;
+    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+        return ExpressionResolverContextUtils.getCurrentValues(context, stepName);
     }
 
     private float dpsToPx(Context context, int value) {

--- a/library/src/main/java/com/vijay/jsonwizard/widgets/TimePickerFactory.java
+++ b/library/src/main/java/com/vijay/jsonwizard/widgets/TimePickerFactory.java
@@ -20,6 +20,7 @@ import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.interfaces.FormWidgetFactory;
 import com.vijay.jsonwizard.interfaces.JsonApi;
 import com.vijay.jsonwizard.utils.DateUtils;
+import com.vijay.jsonwizard.utils.ExpressionResolverContextUtils;
 import com.vijay.jsonwizard.utils.JsonFormUtils;
 import com.vijay.jsonwizard.utils.ValidationStatus;
 import com.vijay.jsonwizard.validators.edittext.RequiredValidator;
@@ -58,12 +59,12 @@ public class TimePickerFactory implements FormWidgetFactory {
                 views = getReadOnlyViewsFromJson(context, jsonObject, bundle);
                 break;
             default:
-                views = getEditableViewsFromJson(context, jsonObject, bundle, resolver);
+                views = getEditableViewsFromJson(stepName, context, jsonObject, bundle, resolver);
         }
         return views;
     }
 
-    private List<View> getEditableViewsFromJson(Context context, JSONObject jsonObject, JsonFormBundle bundle, JsonExpressionResolver resolver)
+    private List<View> getEditableViewsFromJson(String stepName, Context context, JSONObject jsonObject, JsonFormBundle bundle, JsonExpressionResolver resolver)
         throws JSONException {
         List<View> views = new ArrayList<>(1);
         final MaterialEditText editText = (MaterialEditText) LayoutInflater.from(context).inflate(
@@ -97,7 +98,7 @@ public class TimePickerFactory implements FormWidgetFactory {
             if (!TextUtils.isEmpty(requiredValue)) {
                 boolean required = false;
                 if (resolver.isValidExpression(requiredValue)) {
-                    JSONObject currentValues = getCurrentValues(context);
+                    JSONObject currentValues = getCurrentValues(context, stepName);
                     required = resolver.existsExpression(requiredValue, currentValues);
                 } else {
                     required = Boolean.TRUE.toString().equalsIgnoreCase(requiredValue);
@@ -217,14 +218,8 @@ public class TimePickerFactory implements FormWidgetFactory {
     }
 
     @Nullable
-    private JSONObject getCurrentValues(Context context) throws JSONException {
-        JSONObject currentValues = null;
-        if (context instanceof JsonApi) {
-            String currentJsonState = ((JsonApi) context).currentJsonState();
-            JSONObject currentJsonObject = new JSONObject(currentJsonState);
-            currentValues = JsonFormUtils.extractDataFromForm(currentJsonObject, false);
-        }
-        return currentValues;
+    private JSONObject getCurrentValues(Context context, String stepName) throws JSONException {
+        return ExpressionResolverContextUtils.getCurrentValues(context, stepName);
     }
 }
 

--- a/sample/src/main/assets/step-template.json
+++ b/sample/src/main/assets/step-template.json
@@ -2,11 +2,14 @@
   "count": "2",
   "step1": {
     "template": "template0",
+    "template_params": {
+      "address": "a constant"
+    },
     "title": "First step",
     "next": "step2"
   },
   "step2": {
-    "template": "template1",
+    "template": "@.template-definitions/$.ext-template1",
     "next": "step3"
   },
   "step3": {
@@ -59,19 +62,19 @@
     "template1": {
       "fields": [
         {
-          "key":"checkData",
-          "type":"check_box",
-          "label":"Select multiple preferences",
-          "options":[
+          "key": "checkData",
+          "type": "check_box",
+          "label": "Select multiple preferences",
+          "options": [
             {
-              "key":"awesomeness",
-              "text":"Are you willing for some awesomeness?",
-              "value":"false"
+              "key": "awesomeness",
+              "text": "Are you willing for some awesomeness?",
+              "value": "false"
             },
             {
-              "key":"newsletter",
-              "text":"Do you really want to opt out from my newsletter?",
-              "value":"false"
+              "key": "newsletter",
+              "text": "Do you really want to opt out from my newsletter?",
+              "value": "false"
             }
           ]
         },

--- a/sample/src/main/assets/step-template.json
+++ b/sample/src/main/assets/step-template.json
@@ -10,7 +10,10 @@
     "next": "step3"
   },
   "step3": {
-    "template": "template0"
+    "template": "template0",
+    "template_params": {
+      "address": "$.current-values.step1_address"
+    }
   },
   "templates": {
     "template0": {
@@ -26,6 +29,7 @@
           "key": "address",
           "type": "edit_text",
           "hint": "${address.hint}",
+          "value": "$.current-values.template_params.address",
           "readonly": "false",
           "lines": 4
         },

--- a/sample/src/main/assets/step-template.json
+++ b/sample/src/main/assets/step-template.json
@@ -1,0 +1,99 @@
+{
+  "count": "2",
+  "step1": {
+    "template": "template0",
+    "title": "First step",
+    "next": "step2"
+  },
+  "step2": {
+    "template": "template1",
+    "next": "step3"
+  },
+  "step3": {
+    "template": "template0"
+  },
+  "templates": {
+    "template0": {
+      "fields": [
+        {
+          "key": "installation-code",
+          "type": "edit_text",
+          "hint": "${installation-code.hint}",
+          "edit_type": "number",
+          "readonly": "false"
+        },
+        {
+          "key": "address",
+          "type": "edit_text",
+          "hint": "${address.hint}",
+          "readonly": "false",
+          "lines": 4
+        },
+        {
+          "key": "age",
+          "type": "spinner",
+          "hint": "Give Thy Age",
+          "values": [
+            "5-12",
+            "12-19",
+            ">20"
+          ],
+          "labels": [
+            "Child",
+            "Teen",
+            "Adult"
+          ],
+          "v_required": {
+            "value": "true",
+            "err": "Please choose a value to proceed."
+          },
+          "value": "12-19"
+        }
+      ],
+      "title": "${form.title}"
+    },
+    "template1": {
+      "fields": [
+        {
+          "key":"checkData",
+          "type":"check_box",
+          "label":"Select multiple preferences",
+          "options":[
+            {
+              "key":"awesomeness",
+              "text":"Are you willing for some awesomeness?",
+              "value":"false"
+            },
+            {
+              "key":"newsletter",
+              "text":"Do you really want to opt out from my newsletter?",
+              "value":"false"
+            }
+          ]
+        },
+        {
+          "key": "radioData",
+          "type": "radio",
+          "label": "${step1.radioData}",
+          "orientation": "vertical",
+          "options": [
+            {
+              "key": "areYouPro",
+              "text": "Are you pro?"
+            },
+            {
+              "key": "areYouAmature",
+              "text": "Are you amature?"
+            },
+            {
+              "key": "areYouNovice",
+              "text": "Are you novice?"
+            }
+          ],
+          "value": "areYouPro"
+        }
+      ],
+      "title": "${form.title}"
+    }
+  }
+}

--- a/sample/src/main/assets/template-definitions.json
+++ b/sample/src/main/assets/template-definitions.json
@@ -1,0 +1,45 @@
+{
+  "ext-template1": {
+    "fields": [
+      {
+        "key": "checkData",
+        "type": "check_box",
+        "label": "Select multiple preferences",
+        "options": [
+          {
+            "key": "awesomeness",
+            "text": "Are you willing for some awesomeness?",
+            "value": "false"
+          },
+          {
+            "key": "newsletter",
+            "text": "Do you really want to opt out from my newsletter?",
+            "value": "false"
+          }
+        ]
+      },
+      {
+        "key": "radioData",
+        "type": "radio",
+        "label": "${step1.radioData}",
+        "orientation": "vertical",
+        "options": [
+          {
+            "key": "areYouPro",
+            "text": "Are you pro?"
+          },
+          {
+            "key": "areYouAmature",
+            "text": "Are you amature?"
+          },
+          {
+            "key": "areYouNovice",
+            "text": "Are you novice?"
+          }
+        ],
+        "value": "areYouPro"
+      }
+    ],
+    "title": "${form.title}"
+  }
+}


### PR DESCRIPTION
This PR adds the notion of step template in the form definition. 
A step template is a reusable step definition that can be referenced from the form steps. 

Templates are defined as normal steps inside a "templates" property at the document root and is referenced from the step with a template attributed that points to the template name. 

A step may define template_params that will be accessible at the template expansion time

```JSON
{
 "count": 1,
 "step0": {
    "template": "template0"
    "template_params": {
        "address": "Some value or expression"
     }
 },
"templates": {
    "template0": {
      "fields": [
        {
          "key": "installation-code",
          "type": "edit_text",
          "hint": "${installation-code.hint}",
          "edit_type": "number",
          "readonly": "false"
        },
        {
          "key": "address",
          "type": "edit_text",
          "hint": "${address.hint}",
          "value": "$.current-values.template_params.address",
          "readonly": "false",
          "lines": 4
        }
}
}
```